### PR TITLE
Slow database queries & query counters

### DIFF
--- a/src/components/Tabs/DatabaseTab.vue
+++ b/src/components/Tabs/DatabaseTab.vue
@@ -5,28 +5,28 @@
 				<div class="counter-value">{{$request.databaseQueriesCount}}</div>
 				<div class="counter-title">queries</div>
 			</div>
-			<div class="counter slow-query" v-if="$request.databaseSlowQueriesCount">
-				<div class="counter-value">{{$request.databaseSlowQueriesCount}}</div>
-				<div class="counter-title">queries</div>
+			<div class="counter slow-query" v-if="$request.databaseSlowQueries">
+				<div class="counter-value">{{$request.databaseSlowQueries}}</div>
+				<div class="counter-title">slow</div>
 			</div>
-			<div class="counter" v-if="selectsCount">
-				<div class="counter-value">{{selectsCount}}</div>
+			<div class="counter" v-if="$request.databaseSelects">
+				<div class="counter-value">{{$request.databaseSelects}}</div>
 				<div class="counter-title">selects</div>
 			</div>
-			<div class="counter" v-if="insertsCount">
-				<div class="counter-value">{{insertsCount}}</div>
+			<div class="counter" v-if="$request.databaseInserts">
+				<div class="counter-value">{{$request.databaseInserts}}</div>
 				<div class="counter-title">inserts</div>
 			</div>
-			<div class="counter" v-if="updatesCount">
-				<div class="counter-value">{{updatesCount}}</div>
+			<div class="counter" v-if="$request.databaseUpdates">
+				<div class="counter-value">{{$request.databaseUpdates}}</div>
 				<div class="counter-title">updates</div>
 			</div>
-			<div class="counter" v-if="deletesCount">
-				<div class="counter-value">{{deletesCount}}</div>
+			<div class="counter" v-if="$request.databaseDeletes">
+				<div class="counter-value">{{$request.databaseDeletes}}</div>
 				<div class="counter-title">deletes</div>
 			</div>
-			<div class="counter" v-if="otherCount">
-				<div class="counter-value">{{otherCount}}</div>
+			<div class="counter" v-if="$request.databaseOthers">
+				<div class="counter-value">{{$request.databaseOthers}}</div>
 				<div class="counter-title">other</div>
 			</div>
 			<div class="counter">
@@ -78,11 +78,6 @@ export default {
 		])
 	}),
 	computed: {
-		selectsCount() { return this.$request.databaseQueries.filter(query => query.query.match(/^select /i)).length },
-		insertsCount() { return this.$request.databaseQueries.filter(query => query.query.match(/^insert /i)).length },
-		updatesCount() { return this.$request.databaseQueries.filter(query => query.query.match(/^update /i)).length },
-		deletesCount() { return this.$request.databaseQueries.filter(query => query.query.match(/^delete /i)).length },
-		otherCount() { return this.$request.databaseQueries.filter(query => ! query.query.match(/^(select|insert|update|delete) /i)).length },
 		columns() {
 			let columns = [ 'Model', 'Query', 'Duration' ]
 

--- a/src/components/Tabs/DatabaseTab.vue
+++ b/src/components/Tabs/DatabaseTab.vue
@@ -2,7 +2,11 @@
 	<div>
 		<div class="counters-row">
 			<div class="counter">
-				<div class="counter-value">{{queriesCount}}</div>
+				<div class="counter-value">{{$request.databaseQueriesCount}}</div>
+				<div class="counter-title">queries</div>
+			</div>
+			<div class="counter slow-query" v-if="$request.databaseSlowQueriesCount">
+				<div class="counter-value">{{$request.databaseSlowQueriesCount}}</div>
 				<div class="counter-title">queries</div>
 			</div>
 			<div class="counter" v-if="selectsCount">
@@ -33,7 +37,7 @@
 
 		<details-table :columns="columns" :items="$request.databaseQueries" :filter="filter" filter-example="where request_id model:request type:select file:Controller.php duration:&gt;100">
 			<template slot="body" slot-scope="{ items }">
-				<tr v-for="query, index in items" :key="`${$request.id}-${index}`">
+				<tr v-for="query, index in items" :key="`${$request.id}-${index}`" :class="{ 'slow-query': query.tags.includes('slow') }">
 					<td>
 						<shortened-text :full="query.model">{{query.shortModel}}</shortened-text>
 					</td>
@@ -74,7 +78,6 @@ export default {
 		])
 	}),
 	computed: {
-		queriesCount() { return this.$request.databaseQueries.length },
 		selectsCount() { return this.$request.databaseQueries.filter(query => query.query.match(/^select /i)).length },
 		insertsCount() { return this.$request.databaseQueries.filter(query => query.query.match(/^insert /i)).length },
 		updatesCount() { return this.$request.databaseQueries.filter(query => query.query.match(/^update /i)).length },
@@ -92,3 +95,39 @@ export default {
 	}
 }
 </script>
+
+<style lang="scss" scoped>
+.counter.slow-query {
+	border-color: hsl(27, 55%, 65%) !important;
+
+	body.dark & {
+		border-color: hsl(38, 42%, 68%) !important;
+	}
+}
+
+.slow-query {
+	background: rgb(255, 250, 226);
+	color: rgb(168, 89, 25);
+
+	&:nth-child(even) {
+		background: hsl(50, 100%, 88%);
+	}
+
+	.database-query-path /deep/ > a {
+		color: hsl(27, 55%, 65%) !important;
+	}
+
+	body.dark & {
+		background: hsl(50, 100%, 11%);
+		color: rgb(250, 216, 159);
+
+		&:nth-child(even) {
+			background: hsl(50, 100%, 9%);
+		}
+
+		.database-query-path /deep/ > a {
+			color: hsl(38, 42%, 68%) !important;
+		}
+	}
+}
+</style>

--- a/src/components/Tabs/DatabaseTab.vue
+++ b/src/components/Tabs/DatabaseTab.vue
@@ -5,7 +5,7 @@
 				<div class="counter-value">{{$request.databaseQueriesCount}}</div>
 				<div class="counter-title">queries</div>
 			</div>
-			<div class="counter slow-query" v-if="$request.databaseSlowQueries">
+			<div class="counter database-slow-query" v-if="$request.databaseSlowQueries">
 				<div class="counter-value">{{$request.databaseSlowQueries}}</div>
 				<div class="counter-title">slow</div>
 			</div>
@@ -37,7 +37,7 @@
 
 		<details-table :columns="columns" :items="$request.databaseQueries" :filter="filter" filter-example="where request_id model:request type:select file:Controller.php duration:&gt;100">
 			<template slot="body" slot-scope="{ items }">
-				<tr v-for="query, index in items" :key="`${$request.id}-${index}`" :class="{ 'slow-query': query.tags.includes('slow') }">
+				<tr v-for="query, index in items" :key="`${$request.id}-${index}`" :class="{ 'database-slow-query': query.tags.includes('slow') }">
 					<td>
 						<shortened-text :full="query.model">{{query.shortModel}}</shortened-text>
 					</td>
@@ -91,38 +91,27 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped>
-.counter.slow-query {
+<style lang="scss">
+.counter.database-slow-query {
 	border-color: hsl(27, 55%, 65%) !important;
-
-	body.dark & {
-		border-color: hsl(38, 42%, 68%) !important;
-	}
+	body.dark & { border-color: hsl(38, 42%, 68%) !important; }
 }
 
-.slow-query {
+.database-slow-query {
 	background: rgb(255, 250, 226);
 	color: rgb(168, 89, 25);
 
-	&:nth-child(even) {
-		background: hsl(50, 100%, 88%);
-	}
+	&:nth-child(even) { background: hsl(50, 100%, 88%) !important; }
 
-	.database-query-path /deep/ > a {
-		color: hsl(27, 55%, 65%) !important;
-	}
+	.database-query-path > a { color: hsl(27, 55%, 65%) !important; }
 
 	body.dark & {
 		background: hsl(50, 100%, 11%);
 		color: rgb(250, 216, 159);
 
-		&:nth-child(even) {
-			background: hsl(50, 100%, 9%);
-		}
+		&:nth-child(even) { background: hsl(50, 100%, 9%) !important; }
 
-		.database-query-path /deep/ > a {
-			color: hsl(38, 42%, 68%) !important;
-		}
+		.database-query-path > a { color: hsl(38, 42%, 68%) !important; }
 	}
 }
 </style>

--- a/src/components/Tabs/Performance/PerformanceLog.vue
+++ b/src/components/Tabs/Performance/PerformanceLog.vue
@@ -1,0 +1,129 @@
+<template>
+	<div class="performance-log">
+		<details-table :columns="databaseSlowQueriesColumns" :items="databaseSlowQueries" :filter="databaseSlowQueriesFilter" filter-example="where request_id model:request type:select file:Controller.php duration:&gt;100">
+			<template slot="header" slot-scope="{ filter }">
+				<th :colspan="columns.length">
+					Slow database queries <span class="count">{{$request.databaseSlowQueries}}</span>
+					<details-table-filter-toggle :filter="filter"></details-table-filter-toggle>
+				</th>
+			</template>
+			<template slot="body" slot-scope="{ items }">
+				<tr v-for="query, index in items" :key="`${$request.id}-${index}`" :class="{ 'database-slow-query': query.tags.includes('slow') }">
+					<td>
+						<shortened-text :full="query.model">{{query.shortModel}}</shortened-text>
+					</td>
+					<td v-if="columns.includes('Connection')">{{query.connection}}</td>
+					<td>
+						<div class="database-query">
+							<div class="database-query-content">{{query.query}}</div>
+							<stack-trace class="database-query-path" :trace="query.trace" :file="query.file" :line="query.line"></stack-trace>
+						</div>
+					</td>
+					<td class="database-duration">{{query.duration}} ms</td>
+				</tr>
+			</template>
+		</details-table>
+	</div>
+</template>
+
+<script>
+import DetailsTable from '../../UI/DetailsTable'
+import DetailsTableFilterToggle from '../../UI/DetailsTableFilterToggle'
+import ShortenedText from '../../UI/ShortenedText'
+import StackTrace from '../../UI/StackTrace'
+
+import Filter from '../../../features/filter'
+
+export default {
+	name: 'PerformanceLog',
+	components: { DetailsTable, DetailsTableFilterToggle, ShortenedText, StackTrace },
+	data: () => ({
+		databaseSlowQueriesFilter: new Filter([
+			{ tag: 'model' },
+			{ tag: 'type', apply: (item, tagValue) => {
+				if ([ 'select', 'update', 'insert', 'delete' ].includes(tagValue.toLowerCase())) {
+					return item.query.match(new RegExp(`^${tagValue.toLowerCase()}`, 'i'))
+				}
+			} },
+			{ tag: 'file', map: item => item.shortPath },
+			{ tag: 'duration', type: 'number' }
+		])
+	}),
+	computed: {
+		databaseSlowQueriesColumns() {
+			let columns = [ 'Model', 'Query', 'Duration' ]
+
+			let hasMultipleConnections = (new Set(this.databaseSlowQueries.map(query => query.connection))).length > 1
+
+			if (hasMultipleConnections) columns.splice(1, 0, 'Connection')
+
+			return columns
+		},
+		databaseSlowQueries() {
+			return this.$request.databaseQueries.filter(query => query.tags.includes('slow'))
+		}
+	}
+}
+</script>
+
+<style lang="scss">
+.performance-log {
+	margin-top: 25px;
+
+	table {
+		thead {
+			.count {
+				background: hsl(27, 48%, 54%);
+				color: rgb(255, 250, 226);
+				border-radius: 8px;
+				margin-left: 2px;
+				padding: 0 8px;
+
+				body.dark & {
+					background: rgb(250, 216, 159);
+					color: hsl(50, 100%, 11%);
+				}
+			}
+		}
+
+		tr {
+			background: rgb(255, 250, 226);
+			color: rgb(168, 89, 25);
+
+			&:nth-child(even) { background: hsl(50, 100%, 88%); }
+
+			body.dark & {
+				background: hsl(50, 100%, 11%);
+				color: rgb(250, 216, 159);
+
+				&:nth-child(even) { background: hsl(50, 100%, 9%); }
+			}
+
+			&:first-child td {
+				border-top: 1px solid hsl(27, 55%, 65%) !important;
+				body.dark & { border-top: 1px solid hsl(38, 42%, 68%) !important; }
+			}
+
+			.toggle-filter {
+				color: hsl(27, 55%, 65%) !important;
+				body.dark & { color: hsl(38, 42%, 68%) !important; }
+			}
+
+			&.filter {
+				background: rgb(255, 250, 226) !important;
+				body.dark & { background: hsl(50, 100%, 11%) !important; }
+
+				td {
+					border-top: 1px solid hsl(27, 55%, 65%) !important;
+					body.dark & { border-top: 1px solid hsl(38, 42%, 68%) !important; }
+
+					.fa-search, input, .example {
+						color: hsl(27, 55%, 65%) !important;
+						body.dark & { color: hsl(38, 42%, 68%) !important; }
+					}
+				}
+			}
+		}
+	}
+}
+</style>

--- a/src/components/Tabs/Performance/PerformanceLog.vue
+++ b/src/components/Tabs/Performance/PerformanceLog.vue
@@ -2,7 +2,7 @@
 	<div class="performance-log">
 		<details-table :columns="databaseSlowQueriesColumns" :items="databaseSlowQueries" :filter="databaseSlowQueriesFilter" filter-example="where request_id model:request type:select file:Controller.php duration:&gt;100">
 			<template slot="header" slot-scope="{ filter }">
-				<th :colspan="columns.length">
+				<th :colspan="databaseSlowQueriesColumns.length">
 					Slow database queries <span class="count">{{$request.databaseSlowQueries}}</span>
 					<details-table-filter-toggle :filter="filter"></details-table-filter-toggle>
 				</th>
@@ -12,7 +12,7 @@
 					<td>
 						<shortened-text :full="query.model">{{query.shortModel}}</shortened-text>
 					</td>
-					<td v-if="columns.includes('Connection')">{{query.connection}}</td>
+					<td v-if="databaseSlowQueriesColumns.includes('Connection')">{{query.connection}}</td>
 					<td>
 						<div class="database-query">
 							<div class="database-query-content">{{query.query}}</div>

--- a/src/components/Tabs/PerformanceTab.vue
+++ b/src/components/Tabs/PerformanceTab.vue
@@ -20,6 +20,8 @@
 			</div>
 		</div>
 
+		<performance-log v-if="$request.databaseSlowQueries"></performance-log>
+
 		<div tabs="performance">
 			<div class="performance-tabs">
 				<a class="performance-tab" :class="{ 'active': isTabActive('timeline') }" href="#" @click.prevent="showTab('timeline')">Timeline</a>
@@ -33,6 +35,7 @@
 </template>
 
 <script>
+import PerformanceLog from './Performance/PerformanceLog'
 import Profiler from './Performance/Profiler'
 import Timeline from './Performance/Timeline'
 
@@ -40,8 +43,7 @@ import Filter from '../../features/filter'
 
 export default {
 	name: 'PerformanceTab',
-	components: { Profiler, Timeline },
-	props: [ 'request', 'show' ],
+	components: { PerformanceLog, Profiler, Timeline },
 	data: () => ({
 		activeTab: 'timeline'
 	}),

--- a/src/features/request.js
+++ b/src/features/request.js
@@ -13,9 +13,7 @@ export default class Request
 		this.processCacheStats()
 		this.cacheQueries = this.processCacheQueries(this.cacheQueries)
 		this.cookies = this.createKeypairs(this.cookies)
-		this.databaseQueries = this.processDatabaseQueries(this.databaseQueries)
-		this.databaseQueriesCount = this.databaseQueries.length
-		this.databaseSlowQueriesCount = this.databaseQueries.filter(query => query.tags.includes('slow')).length
+		this.processDatabase()
 		this.emails = this.processEmails(this.emailsData)
 		this.events = this.processEvents(this.events)
 		this.getData = this.createKeypairs(this.getData)
@@ -94,6 +92,24 @@ export default class Request
 
 			return query
 		})
+	}
+
+	processDatabase () {
+		this.databaseQueries = this.processDatabaseQueries(this.databaseQueries)
+
+		this.databaseQueriesCount = parseInt(this.databaseQueriesCount) || this.databaseQueries.length
+		this.databaseSlowQueries = parseInt(this.databaseSlowQueries)
+			|| this.databaseQueries.filter(query => query.tags.includes('slow')).length
+		this.databaseSelects = parseInt(this.databaseSelects)
+			|| this.databaseQueries.filter(query => query.query.match(/^select /i)).length
+		this.databaseInserts = parseInt(this.databaseInserts)
+			|| this.databaseQueries.filter(query => query.query.match(/^insert /i)).length
+		this.databaseUpdates = parseInt(this.databaseUpdates)
+			|| this.databaseQueries.filter(query => query.query.match(/^update /i)).length
+		this.databaseDeletes = parseInt(this.databaseDelets)
+			|| this.databaseQueries.filter(query => query.query.match(/^delete /i)).length
+		this.databaseOthers = parseInt(this.databaseOthers)
+			|| this.databaseQueries.filter(query => ! query.query.match(/^(select|insert|update|delete) /i)).length
 	}
 
 	processDatabaseQueries (data) {
@@ -304,7 +320,7 @@ export default class Request
 
 	getWarningsCount () {
 		return this.log.filter(message => message.level == 'warning').length
-			+ this.databaseSlowQueriesCount
+			+ this.databaseSlowQueries
 	}
 
 	formatTime (seconds) {

--- a/src/features/request.js
+++ b/src/features/request.js
@@ -14,6 +14,8 @@ export default class Request
 		this.cacheQueries = this.processCacheQueries(this.cacheQueries)
 		this.cookies = this.createKeypairs(this.cookies)
 		this.databaseQueries = this.processDatabaseQueries(this.databaseQueries)
+		this.databaseQueriesCount = this.databaseQueries.length
+		this.databaseSlowQueriesCount = this.databaseQueries.filter(query => query.tags.includes('slow')).length
 		this.emails = this.processEmails(this.emailsData)
 		this.events = this.processEvents(this.events)
 		this.getData = this.createKeypairs(this.getData)
@@ -100,6 +102,7 @@ export default class Request
 		return data.map(query => {
 			query.model = query.model || '-'
 			query.shortModel = query.model ? query.model.split('\\').pop() : '-'
+			query.tags = query.tags instanceof Array ? query.tags : []
 
 			return query
 		})
@@ -300,9 +303,8 @@ export default class Request
 	}
 
 	getWarningsCount () {
-		return this.log.reduce((count, message) => {
-			return message.level == 'warning' ? count + 1 : count
-		}, 0)
+		return this.log.filter(message => message.level == 'warning').length
+			+ this.databaseSlowQueriesCount
 	}
 
 	formatTime (seconds) {

--- a/src/main.scss
+++ b/src/main.scss
@@ -168,7 +168,7 @@ a {
 
 			.toggle-filter {
 				position: absolute;
-				right: 0;
+				right: 4px;
 				top: 4px;
 				visibility: hidden;
 			}


### PR DESCRIPTION
- added highlighting of slow queries in the "database" tab
- added slow query log to the "performance" tab
- the warnings count in the requests list now includes slow queries count
- added support for query counters in metadata (with fallback to counting the collected queries themselves)
- server-side PR https://github.com/itsgoingd/clockwork/pull/314

<img width="1392" alt="Screenshot 2019-03-23 at 20 44 40" src="https://user-images.githubusercontent.com/821582/54885701-80c94d00-4e7f-11e9-9401-90cac2b49784.png">

<img width="1392" alt="Screenshot 2019-03-23 at 20 37 07" src="https://user-images.githubusercontent.com/821582/54885703-84f56a80-4e7f-11e9-8e75-41f1e087e849.png">
