### PR TITLE
Added performance warnings to the "performance" tab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6374,6 +6374,11 @@
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
       "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw=="
     },
+    "just-omit": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/just-omit/-/just-omit-1.1.0.tgz",
+      "integrity": "sha512-MBDr0a1Yyzht8KK3RS2oUKtJSKRrm+6txDuEFJOXoALnX4h+FcQyWSKVNDlZiClOSIRf1PkzJ+QkKm0pjLS7Mw=="
+    },
     "killable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "chart.js": "^2.7.3",
     "just-clone": "^3.1.0",
     "just-extend": "^4.0.2",
+    "just-omit": "^1.1.0",
     "lodash": "^4.17.11",
     "register-service-worker": "^1.0.0",
     "urijs": "^1.19.1",

--- a/src/components/Tabs/LogTab.vue
+++ b/src/components/Tabs/LogTab.vue
@@ -1,6 +1,6 @@
 <template>
 	<div>
-		<details-table :columns="['Time', 'Level', 'Message']" :items="$request.log" :filter="filter" filter-example="query failed level:error file:Controller.php time:>13:08:29">
+		<details-table :columns="['Time', 'Level', 'Message']" :items="log" :filter="filter" filter-example="query failed level:error file:Controller.php time:>13:08:29">
 			<template slot="body" slot-scope="{ items }">
 				<tr v-for="message, index in items" :class="{ 'log-row': true, 'error': ['emergency', 'alert', 'critical', 'error'].includes(message.level), warning: message.level == 'warning' }" :key="`${$request.id}-${index}`">
 					<td class="log-date">{{message.time | moment('HH:mm:ss')}}</td>
@@ -44,6 +44,9 @@ export default {
 			{ tag: 'file', map: item => item.shortPath }
 		], item => item.message)
 	}),
+	computed: {
+		log() { return this.$request.log.filter(message => ! message.context?.performance) }
+	},
 	methods: {
 		showPreviousException: function (message) {
 			let messageIndex = this.$request.log.indexOf(message)


### PR DESCRIPTION
- added performance warnings to the "performance" tabs
- performance warnings are any log messages with `[ "performance" => true ]` in the context

<img width="1324" alt="Screenshot 2019-04-03 at 23 14 17" src="https://user-images.githubusercontent.com/821582/55513872-0f4f8280-5667-11e9-9fd3-ab2e7b62b8d0.png">
