### PR TITLE
Added simple pagination for tables

### DIFF
--- a/src/features/filter.js
+++ b/src/features/filter.js
@@ -12,7 +12,7 @@ export default class Filter
 		this.input = ''
 	}
 
-	toggle () {
+	toggle ($event) {
 		this.shown = ! this.shown
 
 		if (this.shown) {


### PR DESCRIPTION
- added simple pagination for tables, 30 items are shown at a time, with ability to show next/previous 30 items
- this is a major performance improvement for large tables as Vue is pretty slow when rendering large lists esp. with sub-components

<img width="1319" alt="Screenshot 2019-04-28 at 22 18 45" src="https://user-images.githubusercontent.com/821582/56869855-98f43500-6a06-11e9-94dc-785707ac9af4.png">
