### PR TITLE
Fixing "Cannot read property 'split' of null" issue

### DIFF
--- a/src/features/text-filters.js
+++ b/src/features/text-filters.js
@@ -7,6 +7,6 @@ export default class TextFilters
 	}
 
 	shortClass (className) {
-		return className.split('\\').pop()
+		return className && className.split('\\').pop()
 	}
 }


### PR DESCRIPTION
Sometimes className is null and Uncaught TypeError (Cannot read property 'split' of null) occurs, here is a simple fix.