### PR TITLE
Fixed PHPStorm file url

### DIFF
--- a/src/features/editor-links.js
+++ b/src/features/editor-links.js
@@ -14,7 +14,7 @@ export default class EditorLinks
 		return (file, line) => {
 			let scheme = {
 				'atom': (file, line) => `atom://open?url=file://${file}&line=${line}`,
-				'phpstorm': (file, line) => `phpstorm://open?url=file://${file}&line=${line}`,
+				'phpstorm': (file, line) => `phpstorm://open?file=${file}&line=${line}`,
 				'sublime': (file, line) => `subl://open?url=file://${file}&line=${line}`,
 				'textmate': (file, line) => `txmt://open?url=file://${file}&line=${line}`,
 				'vs-code': (file, line) => `vscode://file/${file}:${line}`


### PR DESCRIPTION
Hi!
Fixed PHPStorm links. 

Reference ([Ignition for Laravel](https://github.com/facade/ignition)):

https://github.com/facade/ignition/blob/b9081637e856ae55a7c5ff981750696c0d983f3d/resources/js/components/Shared/editorUrl.js#L8