### PR TITLE
Added support for debugging tests

### DIFF
--- a/src/components/RequestSidebar.vue
+++ b/src/components/RequestSidebar.vue
@@ -9,6 +9,9 @@
 				<template v-else-if="$request && $request.isQueueJob()">
 					Queue job
 				</template>
+				<template v-else-if="$request && $request.isTest()">
+					Test
+				</template>
 				<template v-else>
 					Request
 				</template>
@@ -33,6 +36,7 @@
 
 			<command-tab v-if="$request && $request.isCommand()"></command-tab>
 			<queue-job-tab v-if="$request && $request.isQueueJob()"></queue-job-tab>
+			<test-tab v-if="$request && $request.isTest()"></test-tab>
 			<request-tab v-else-if="$request"></request-tab>
 
 			<div class="sidebar-date" v-if="$request && $request.time">
@@ -50,10 +54,11 @@ import ExceptionSection from './Sidebar/ExceptionSection'
 import ParentRequest from './Sidebar/ParentRequest'
 import QueueJobTab from './Tabs/QueueJobTab'
 import RequestTab from './Tabs/RequestTab'
+import TestTab from './Tabs/TestTab'
 
 export default {
 	name: 'RequestSidebar',
-	components: { CommandTab, ExceptionSection, ParentRequest, QueueJobTab, RequestTab },
+	components: { CommandTab, ExceptionSection, ParentRequest, QueueJobTab, RequestTab, TestTab },
 	methods: {
 		togglePreserveLog() {
 			this.$store.set('preserveLog', ! this.$store.get('preserveLog'))

--- a/src/components/RequestsList.vue
+++ b/src/components/RequestsList.vue
@@ -132,6 +132,10 @@ export default {
 				return this.$requests.items.filter(request => request.type != 'queue-job')
 			}
 
+			if (this.$settings.global.hideTestTypeRequests) {
+				return this.$requests.items.filter(request => request.type != 'test')
+			}
+
 			return this.$requests.items
 		}
 	},

--- a/src/components/RequestsList.vue
+++ b/src/components/RequestsList.vue
@@ -56,6 +56,10 @@
 								<span class="type-text">QUEUE</span>
 								{{request.jobName}}
 							</template>
+							<template v-else-if="request.isTest()">
+								<span class="type-text">TEST</span>
+								{{request.testGroup}}
+							</template>
 							<template v-else>
 								<span v-if="request.isAjax()" class="type-text">AJAX</span>
 								<span class="method-text">{{request.method}}</span> {{request.uri}}
@@ -67,6 +71,9 @@
 						</template>
 						<template v-else-if="request.isQueueJob()">
 							<small>{{request.jobDescription}}</small>
+						</template>
+						<template v-else-if="request.isTest()">
+							<small>{{request.testName}}</small>
 						</template>
 						<template v-else>
 							<small v-if="$store.data.requestSidebarCollapsed">{{request.controller}}</small>
@@ -81,6 +88,11 @@
 					<template v-else-if="request.isQueueJob()">
 						<td class="status" :title="request.jobStatus">
 							<span :class="{ 'status-text': true, 'status-text-small': true, 'client-error': request.isQueueJobWarning(), 'server-error': request.isQueueJobError() }">{{request.jobStatus}}</span>
+						</td>
+					</template>
+					<template v-else-if="request.isTest()">
+						<td class="status" :title="request.testStatus">
+							<span :class="{ 'status-text': true, 'status-text-small': true, 'client-error': request.isTestWarning(), 'server-error': request.isTestError() }">{{request.testStatus}}</span>
 						</td>
 					</template>
 					<template v-else>
@@ -333,7 +345,7 @@ export default {
 		font-size: 115%;
 	}
 
-	.method, .status {
+	.status {
 		text-align: center;
 		width: 52px;
 	}

--- a/src/components/Settings/SettingsModal.vue
+++ b/src/components/Settings/SettingsModal.vue
@@ -83,6 +83,10 @@
 						<input type="checkbox" v-model="$settings.global.hideQueueJobTypeRequests" @change="save">
 						Hide queue jobs in requests list
 					</label>
+					<label class="controls-checkbox">
+						<input type="checkbox" v-model="$settings.global.hideTestTypeRequests" @change="save">
+						Hide tests in requests list
+					</label>
 				</div>
 			</div>
 		</div>
@@ -243,10 +247,10 @@ export default {
 }
 
 .settings-enter-active, .settings-leave-active {
-	transition: top .5s;
+	transition: top .33s;
 }
 
 .settings-enter, .settings-leave-to {
-	top: -350px;
+	top: -400px;
 }
 </style>

--- a/src/components/Tabs/TestTab.vue
+++ b/src/components/Tabs/TestTab.vue
@@ -60,10 +60,14 @@ export default {
 	    margin-bottom: 3px;
 	    white-space: nowrap;
 	    margin-bottom: 5px;
-	    color: #586336;
+	    color: hsla(75, 65%, 30%, 1);
+
+	    @include dark { color: hsl(75, 76%, 70%); }
 
 	    &.assert-failed {
 	    	color: #c51f24;
+
+	    	@include dark { color: #ed797a; }
 	    }
 	}
 

--- a/src/components/Tabs/TestTab.vue
+++ b/src/components/Tabs/TestTab.vue
@@ -1,0 +1,76 @@
+<template>
+	<div class="request-tab test-tab">
+		<div class="test-status-message" v-if="$request.testStatusMessage">
+			{{$request.testStatusMessage}}
+		</div>
+
+		<sidebar-section title="Asserts" name="asserts" :items="asserts" filter-example="text/html name:Accept" v-show="asserts.length">
+			<template slot="table" slot-scope="{ items, filter, filterExample, expanded }">
+				<details-table :columns="['Assert']" :items="items" :filter="filter" :filter-example="filterExample" :no-header="true" v-show="expanded">
+					<template slot="header" slot-scope="{ filter }">
+					</template>
+					<template slot="body" slot-scope="{ items }">
+						<tr v-for="item, index in items" :key="`${$request.id}-${index}`">
+							<td class="value test-assert">
+								<div class="test-assert-name" :class="{'assert-failed': ! item.passed}">{{item.name}}</div>
+								<pretty-print :data="item.arguments"></pretty-print>
+							</td>
+						</tr>
+					</template>
+				</details-table>
+			</template>
+		</sidebar-section>
+	</div>
+</template>
+
+<script>
+import DetailsTable from '../UI/DetailsTable'
+import PrettyPrint from '../UI/PrettyPrint'
+import SidebarSection from '../UI/SidebarSection'
+import StackTrace from '../UI/StackTrace'
+
+export default {
+	name: 'TestTab',
+	components: { DetailsTable, PrettyPrint, SidebarSection, StackTrace },
+	computed: {
+		asserts() {
+			return this.$request.testAsserts.reverse()
+		}
+	}
+}
+</script>
+
+<style lang="scss">
+@import '../../mixins.scss';
+
+.test-tab {
+	.test-status-message {
+		border-bottom: 1px solid rgb(209, 209, 209);
+		background: rgb(255, 235, 235);
+		color: rgb(197, 31, 36);
+	    padding: 12px 10px;
+	    font-size: 13px;
+
+		@include dark { border-bottom: 1px solid rgb(54, 54, 54); }
+	}
+
+	.test-assert-name {
+	    font-size: 11px;
+	    font-weight: 600;
+	    margin-bottom: 3px;
+	    white-space: nowrap;
+	    margin-bottom: 5px;
+	    color: #586336;
+
+	    &.assert-failed {
+	    	color: #c51f24;
+	    }
+	}
+
+	.test-assert {
+		.pretty-jason {
+			font-size: 11px;
+		}
+	}
+}
+</style>

--- a/src/components/Tabs/TestTab.vue
+++ b/src/components/Tabs/TestTab.vue
@@ -12,7 +12,12 @@
 					<template slot="body" slot-scope="{ items }">
 						<tr v-for="item, index in items" :key="`${$request.id}-${index}`">
 							<td class="value test-assert">
-								<div class="test-assert-name" :class="{'assert-failed': ! item.passed}">{{item.name}}</div>
+								<div class="assert-name">
+									<div class="assert-name-content" :class="{'assert-failed': ! item.passed}">{{item.name}}</div>
+									<div class="assert-name-trace">
+										<stack-trace :trace="item.trace"></stack-trace>
+									</div>
+								</div>
 								<pretty-print :data="item.arguments"></pretty-print>
 							</td>
 						</tr>
@@ -54,24 +59,35 @@ export default {
 		@include dark { border-bottom: 1px solid rgb(54, 54, 54); }
 	}
 
-	.test-assert-name {
-	    font-size: 11px;
-	    font-weight: 600;
-	    margin-bottom: 3px;
-	    white-space: nowrap;
-	    margin-bottom: 5px;
-	    color: hsla(75, 65%, 30%, 1);
-
-	    @include dark { color: hsl(75, 76%, 70%); }
-
-	    &.assert-failed {
-	    	color: #c51f24;
-
-	    	@include dark { color: #ed797a; }
-	    }
-	}
-
 	.test-assert {
+		.assert-name {
+			display: flex;
+			flex-wrap: wrap;
+
+			.assert-name-content {
+				flex: 1 0 auto;
+			    font-size: 11px;
+			    font-weight: 600;
+			    margin-bottom: 3px;
+				max-width: 100%;
+			    white-space: nowrap;
+			    margin-bottom: 5px;
+			    color: hsla(75, 65%, 30%, 1);
+
+			    @include dark { color: hsl(75, 76%, 70%); }
+
+			    &.assert-failed {
+			    	color: #c51f24;
+
+			    	@include dark { color: #ed797a; }
+			    }
+			}
+
+			.assert-name-trace {
+				flex: 0;
+			}
+		}
+
 		.pretty-jason {
 			font-size: 11px;
 		}

--- a/src/components/UI/StackTrace.vue
+++ b/src/components/UI/StackTrace.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="stack-trace popover-container" v-click-outside="closePopover">
-		<a :href="file | editorLink(line)" v-if="file">
+		<a :href="file || trace[0].file | editorLink(line)" v-if="file || trace.length">
 			<shortened-text :full="trace ? shortPath : fullPath" @click.native="togglePopover($event)">{{shortPath}}</shortened-text>
 		</a>
 		<a href="#" v-else title="Stack trace">
@@ -30,15 +30,15 @@ import PrettyJason from '../../features/pretty-jason/pretty-jason'
 import ShortenedText from './ShortenedText'
 
 export default {
-	name: 'PrettyPrint',
+	name: 'StackTrace',
 	components: { ShortenedText },
 	props: [ 'trace', 'file', 'line' ],
 	data: () => ({
 		showPopover: false
 	}),
 	computed: {
-		fullPath() { return this.makeFullPath(this.file, this.line) },
-		shortPath() { return this.makeShortPath(this.file, this.line) }
+		fullPath() { return this.makeFullPath(this.file || this.trace[0].file, this.line || this.trace[0].line) },
+		shortPath() { return this.makeShortPath(this.file || this.trace[0].file, this.line || this.trace[0].line) }
 	},
 	methods: {
 		closePopover() {

--- a/src/features/request.js
+++ b/src/features/request.js
@@ -33,6 +33,7 @@ export default class Request
 		this.userData = this.processUserData(this.userData)
 		this.processCommand()
 		this.processQueueJob()
+		this.processTest()
 
 		this.errorsCount = this.getErrorsCount()
 		this.warningsCount = this.getWarningsCount()
@@ -107,6 +108,18 @@ export default class Request
 
 	isQueueJobWarning() {
 		return this.jobStatus == 'released'
+	}
+
+	isTest() {
+		return this.type == 'test'
+	}
+
+	isTestError() {
+		return [ 'failed', 'error' ].includes(this.testStatus)
+	}
+
+	isTestWarning() {
+		return [ 'warning' ].includes(this.testStatus)
 	}
 
 	get tooltip() {
@@ -303,6 +316,11 @@ export default class Request
 
 	processRedisCommands(data) {
 		return data instanceof Array ? data : []
+	}
+
+	processTest() {
+		[ this.testGroup, this.testName ] = this.testName.includes('::')
+			? this.testName.split('::') : [ this.testName, '' ];
 	}
 
 	processTimeline(data) {

--- a/src/features/request.js
+++ b/src/features/request.js
@@ -127,6 +127,8 @@ export default class Request
 			return `[CMD] ${this.commandName} (${this.commandLine})`
 		} else if (this.isQueueJob()) {
 			return `[QUEUE] ${this.jobName} (${this.jobDescription})`
+		} else if (this.isTest()) {
+			return `[TEST] ${this.testGroup} (${this.testName})`
 		} else {
 			return `${this.method} ${this.uri} (${this.controller})`
 		}
@@ -319,6 +321,8 @@ export default class Request
 	}
 
 	processTest() {
+		if (! this.testName) return
+
 		[ this.testGroup, this.testName ] = this.testName.includes('::')
 			? this.testName.split('::') : [ this.testName, '' ];
 	}

--- a/src/features/settings.js
+++ b/src/features/settings.js
@@ -55,7 +55,8 @@ export default class Settings
 				editor: null,
 				showIncomingRequests: true,
 				hideCommandTypeRequests: this.platform instanceof Extension,
-				hideQueueJobTypeRequests: this.platform instanceof Extension
+				hideQueueJobTypeRequests: this.platform instanceof Extension,
+				hideTestTypeRequests: this.platform instanceof Extension
 			},
 			site: {
 				localPathMap: { real: null, local: null }

--- a/src/platform/extension.js
+++ b/src/platform/extension.js
@@ -110,7 +110,7 @@ export default class Extension
 
 			this.requests.setRemote(message.request.url, options)
 
-			if (! this.settings.global.hideCommandTypeRequests || ! this.settings.global.hideQueueJobTypeRequests) {
+			if (! this.settings.global.hideCommandTypeRequests || ! this.settings.global.hideQueueJobTypeRequests || ! this.settings.global.hideTestTypeRequests) {
 				this.startPollingRequests()
 			}
 		})
@@ -142,7 +142,7 @@ export default class Extension
 				this.requests.setRemote(request.url, options)
 				this.requests.loadId(options.id, Request.placeholder(options.id, request))
 
-				if (! this.settings.global.hideCommandTypeRequests || ! this.settings.global.hideQueueJobTypeRequests) {
+				if (! this.settings.global.hideCommandTypeRequests || ! this.settings.global.hideQueueJobTypeRequests || ! this.settings.global.hideTestTypeRequests) {
 					this.startPollingRequests()
 				}
 			}
@@ -216,7 +216,7 @@ export default class Extension
 	}
 
 	settingsChanged() {
-		if (this.settings.global.hideCommandTypeRequests && this.settings.global.hideQueueJobTypeRequests) {
+		if (this.settings.global.hideCommandTypeRequests && this.settings.global.hideQueueJobTypeRequests && this.settings.global.hideTestTypeRequests) {
 			this.stopPollingRequests()
 		} else {
 			this.startPollingRequests()


### PR DESCRIPTION
- added support for "test" type requests
- show test-specific metadata in requests list including test name and status (passed, failed, etc.)
- new "test" tab shown in sidebar shows executed asserts, including pretty-printed arguments, failure message for failed tests and stack traces
- all other features work the same as when debugging http requests, eg. timeline, database queries, etc.
- server-side PR - https://github.com/itsgoingd/clockwork/pull/360

<img width="1321" alt="Screenshot 2019-11-05 at 00 39 07" src="https://user-images.githubusercontent.com/821582/68167477-eb8a4d00-ff65-11e9-96c7-13acc8542c9b.png">
