### PR TITLE
Added support for commands debugging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1646,6 +1646,14 @@
         "color-convert": "^1.9.0"
       }
     },
+    "ansi-to-html": {
+      "version": "0.6.13",
+      "resolved": "https://registry.npmjs.org/ansi-to-html/-/ansi-to-html-0.6.13.tgz",
+      "integrity": "sha512-Ys2/umuaTlQvP9DLkaa7UzRKF2FLrfod/hNHXS9QhXCrw7seObG6ksOGmNz3UoK+adwM8L9vQfG7mvaxfJ3Jvw==",
+      "requires": {
+        "entities": "^1.1.2"
+      }
+    },
     "any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -4358,8 +4366,7 @@
     "entities": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
-      "dev": true
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
     },
     "errno": {
       "version": "0.1.7",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@fortawesome/free-regular-svg-icons": "^5.9.0",
     "@fortawesome/free-solid-svg-icons": "^5.9.0",
     "@fortawesome/vue-fontawesome": "^0.1.6",
+    "ansi-to-html": "^0.6.13",
     "chart.js": "^2.8.0",
     "just-clone": "^3.1.0",
     "just-debounce-it": "^1.1.0",

--- a/src/components/RequestDetails.vue
+++ b/src/components/RequestDetails.vue
@@ -26,6 +26,7 @@
 				<tab-handle name="emails" :active="isTabActive('emails')" @tab-selected="showTab" v-show="showEmailsTab">Emails</tab-handle>
 				<tab-handle name="routes" :active="isTabActive('routes')" @tab-selected="showTab" v-show="showRoutesTab">Routes</tab-handle>
 				<tab-handle v-for="userTab in $get($request, 'userData')" :key="`${$request.id}-${userTab.key}`" :name="`user-${userTab.key}`" :active="isTabActive(`user-${userTab.key}`)" @tab-selected="showTab">{{ userTab.title }}</tab-handle>
+				<tab-handle name="output" :active="isTabActive('output')" @tab-selected="showTab" v-show="showOutputTab">Output</tab-handle>
 			</div>
 
 			<div class="icons">
@@ -60,6 +61,7 @@
 			<emails-tab v-show="isTabActive('emails')"></emails-tab>
 			<routes-tab v-show="isTabActive('routes')"></routes-tab>
 			<user-tab v-for="userTab, index in $get($request, 'userData')" :key="`${$request.id}-${index}`" :user-tab="userTab" v-show="isTabActive(`user-${userTab.key}`)"></user-tab>
+			<output-tab v-show="isTabActive('output')"></output-tab>
 
 		</div>
 
@@ -103,6 +105,7 @@ import DatabaseTab from './Tabs/DatabaseTab'
 import EmailsTab from './Tabs/EmailsTab'
 import EventsTab from './Tabs/EventsTab'
 import LogTab from './Tabs/LogTab'
+import OutputTab from './Tabs/OutputTab'
 import PerformanceTab from './Tabs/PerformanceTab'
 import RedisTab from './Tabs/RedisTab'
 import QueueTab from './Tabs/QueueTab'
@@ -113,7 +116,7 @@ import ViewsTab from './Tabs/ViewsTab'
 export default {
 	name: 'RequestDetails',
 	components: {
-		MessagesOverlay, SettingsModal, TabHandle, CacheTab, DatabaseTab, EmailsTab, EventsTab, LogTab,
+		MessagesOverlay, SettingsModal, TabHandle, CacheTab, DatabaseTab, EmailsTab, EventsTab, LogTab, OutputTab,
 		PerformanceTab, RedisTab, QueueTab, RoutesTab, UserTab, ViewsTab
 	},
 	data: () => ({
@@ -133,7 +136,8 @@ export default {
 		showEventsTab() { return this.$request?.events?.length },
 		showViewsTab() { return this.$request?.views?.length },
 		showEmailsTab() { return this.$request?.emails?.length },
-		showRoutesTab() { return this.$request?.routes?.length }
+		showRoutesTab() { return this.$request?.routes?.length },
+		showOutputTab() { return this.$request?.commandOutput }
 	},
 	methods: {
 		isTabActive(tab) { return this.$request && this.activeTab == tab },

--- a/src/components/RequestSidebar.vue
+++ b/src/components/RequestSidebar.vue
@@ -3,7 +3,12 @@
 
 		<div class="sidebar-header">
 			<div class="sidebar-title">
-				Request
+				<template v-if="$request && $request.isCommand()">
+					Command
+				</template>
+				<template v-else>
+					Request
+				</template>
 			</div>
 
 			<div class="sidebar-actions">
@@ -20,7 +25,8 @@
 		</div>
 
 		<div class="sidebar-content">
-			<request-tab v-if="$request"></request-tab>
+			<command-tab v-if="$request && $request.isCommand()"></command-tab>
+			<request-tab v-else-if="$request"></request-tab>
 
 			<div class="sidebar-date" v-if="$request && $request.time">
 				{{ $request.time * 1000 | moment('Y-MM-DD HH:mm:ss') }}
@@ -32,11 +38,12 @@
 </template>
 
 <script>
+import CommandTab from './Tabs/CommandTab'
 import RequestTab from './Tabs/RequestTab'
 
 export default {
 	name: 'RequestSidebar',
-	components: { RequestTab },
+	components: { CommandTab, RequestTab },
 	methods: {
 		togglePreserveLog() {
 			this.$store.set('preserveLog', ! this.$store.get('preserveLog'))

--- a/src/components/RequestsList.vue
+++ b/src/components/RequestsList.vue
@@ -38,7 +38,7 @@
 					<td class="duration"></td>
 				</tr>
 				<tr v-for="request in $requests.items" :key="request.id" @click="showRequest(request)" :class="{ selected: isActive(request.id) }">
-					<td class="controller" :title="`${request.method} ${request.uri} (${request.controller})`">
+					<td class="controller" :title="request.tooltip">
 						<div class="notifications-count">
 							<span class="warnings-count" v-show="request.warningsCount">
 								<font-awesome-icon icon="exclamation-triangle"></font-awesome-icon> {{request.warningsCount}}
@@ -48,16 +48,34 @@
 							</span>
 						</div>
 						<big>
-							<span v-if="request.isAjax()" class="is-ajax">AJAX</span>
-							<span class="method-text">{{request.method}}</span> {{request.uri}}
+							<template v-if="request.isCommand()">
+								<span class="type-text">CMD</span>
+								{{request.commandName}}
+							</template>
+							<template v-else>
+								<span v-if="request.isAjax()" class="type-text">AJAX</span>
+								<span class="method-text">{{request.method}}</span> {{request.uri}}
+							</template>
 						</big>
 						<br>
-						<small v-if="$store.data.requestSidebarCollapsed">{{request.controller}}</small>
-						<small v-else>{{request.controller | shortClass}}</small>
+						<template v-if="request.isCommand()">
+							<small>{{request.commandLine}}</small>
+						</template>
+						<template v-else>
+							<small v-if="$store.data.requestSidebarCollapsed">{{request.controller}}</small>
+							<small v-else>{{request.controller | shortClass}}</small>
+						</template>
 					</td>
-					<td class="status" :title="request.responseStatus">
-						<span :class="{ 'status-text': true, 'client-error': request.isClientError(), 'server-error': request.isServerError() }">{{request.responseStatus}}</span>
-					</td>
+					<template v-if="request.isCommand()">
+						<td class="status" :title="request.commandExitCode">
+							<span :class="{ 'status-text': true, 'client-error': request.isCommandWarning(), 'server-error': request.isCommandError() }">{{request.commandExitCode}}</span>
+						</td>
+					</template>
+					<template v-else>
+						<td class="status" :title="request.responseStatus">
+							<span :class="{ 'status-text': true, 'client-error': request.isClientError(), 'server-error': request.isServerError() }">{{request.responseStatus}}</span>
+						</td>
+					</template>
 					<td class="duration" :title="`${request.responseDurationRounded} ms (${request.databaseDurationRounded} ms)`">
 						{{request.responseDurationRounded}} ms<br>
 						<small>{{request.databaseDurationRounded}} ms</small>
@@ -231,7 +249,7 @@ export default {
 				@include dark { color: white; }
 			}
 
-			.status-text, .is-ajax {
+			.status-text, .type-text {
 				background: transparent;
 				color: #fff;
 
@@ -303,14 +321,14 @@ export default {
 		width: 68px;
 	}
 
-	.is-ajax {
+	.type-text {
 		background: hsla(206, 47%, 86%, 1);
 		border-radius: 3px;
 		color: hsla(205, 29%, 30%, 1);
 		font-size: 80%;
-		margin-bottom: 1px;
 		margin-right: 2px;
 		padding: 1px 3px;
+		vertical-align: 1px;
 
 		@include dark {
 			background: hsla(206, 100%, 16%, 1);

--- a/src/components/RequestsList.vue
+++ b/src/components/RequestsList.vue
@@ -37,7 +37,7 @@
 					<td class="status"></td>
 					<td class="duration"></td>
 				</tr>
-				<tr v-for="request in $requests.items" :key="request.id" @click="showRequest(request)" :class="{ selected: isActive(request.id) }">
+				<tr v-for="request in requests" :key="request.id" @click="showRequest(request)" :class="{ selected: isActive(request.id) }">
 					<td class="controller" :title="request.tooltip">
 						<div class="notifications-count">
 							<span class="warnings-count" v-show="request.warningsCount">
@@ -99,7 +99,13 @@ export default {
 		loadingMoreRequests: false
 	}),
 	computed: {
-		requests() { return this.$requests.items }
+		requests() {
+			if (this.$settings.global.hideCommandTypeRequests) {
+				return this.$requests.items.filter(request => request.type != 'command')
+			}
+
+			return this.$requests.items
+		}
 	},
 	mounted() {
 		this.$refs.requestsContainer.scrollTop = this.$refs.loadMore.offsetHeight + 1

--- a/src/components/Settings/SettingsModal.vue
+++ b/src/components/Settings/SettingsModal.vue
@@ -70,6 +70,17 @@
 					</label>
 				</div>
 			</div>
+
+			<div class="controls-group">
+				<label></label>
+
+				<div class="controls">
+					<label>
+						<input type="checkbox" v-model="$settings.global.hideCommandTypeRequests" @change="save">
+						Hide commands in requests list
+					</label>
+				</div>
+			</div>
 		</div>
 	</transition>
 </template>

--- a/src/components/Tabs/CommandTab.vue
+++ b/src/components/Tabs/CommandTab.vue
@@ -1,0 +1,103 @@
+<template>
+	<div class="command-tab">
+		<div class="exception" v-if="$request && $request.exceptions.length">
+			<div class="exception-info" v-for="exception, index in $request.exceptions" :key="`${$request.id}-${index}`">
+				<div class="exception-message">
+					<h3>{{exception.type}} <small v-if="exception.code">#{{exception.code}}</small></h3>
+					{{exception.message}}
+				</div>
+				<div>
+					<a href="#" class="exception-previous" @click.prevent="showPreviousException(exception)" v-if="exception.previous" title="Show previous">
+						<font-awesome-icon icon="arrow-circle-down"></font-awesome-icon>
+					</a>
+					<stack-trace class="exception-trace" :trace="exception.trace"></stack-trace>
+				</div>
+			</div>
+		</div>
+
+		<sidebar-section title="Arguments" name="arguments" :items="$request.commandArgumentsMerged" filter-example="&quot;Mike Jones&quot; name:name" v-show="$request.commandArgumentsMerged.length">
+		</sidebar-section>
+
+		<sidebar-section title="Options" name="options" :items="$request.commandOptionsMerged" filter-example="&quot;Mike Jones&quot; name:name" v-show="$request.commandOptionsMerged.length">
+		</sidebar-section>
+	</div>
+</template>
+
+<script>
+import SidebarSection from '../UI/SidebarSection'
+
+export default {
+	name: 'CommandTab',
+	components: { SidebarSection },
+	methods: {
+		showPreviousException(exception) {
+			this.$request.exceptions.push(exception.previous)
+			exception.previous = undefined
+		}
+	}
+}
+</script>
+
+<style lang="scss">
+@import '../../mixins.scss';
+
+.command-tab {
+	background: #fff;
+
+	@include dark { background: #1f1f1f; }
+
+	.exception {
+		border-bottom: 1px solid rgb(209, 209, 209);
+
+		@include dark { border-bottom: 1px solid rgb(54, 54, 54); }
+
+		.exception-info {
+			align-items: center;
+			background: rgb(255, 235, 235);
+			color: rgb(197, 31, 36);
+		    display: flex;
+		    padding: 6px 10px;
+
+			&:nth-child(even) { background: hsl(0, 100%, 94%); }
+			&:first-child { padding-top: 12px; }
+			&:last-child { padding-bottom: 12px; }
+
+			@include dark {
+				background: hsl(0, 100%, 11%);
+				color: rgb(237, 121, 122);
+
+				&:nth-child(even) { background: hsl(0, 100%, 9%); }
+			}
+
+			h3 {
+			    border-bottom: 0;
+			    font-size: 14px;
+			    margin: 0 0 5px;
+			}
+
+		    .exception-message {
+			    flex: 1;
+	    	    font-size: 12px;
+			    line-height: 1.5;
+		    }
+
+    		.exception-previous, .exception-trace > a {
+				color: rgb(197, 31, 36);
+			    font-size: 12px;
+			    margin: 0 4px;
+
+				@include dark { color: rgb(237, 121, 122); }
+			}
+
+			.exception-previous {
+				margin-right: 4px;
+				text-decoration: none;
+			}
+
+			.exception-trace {
+				display: inline-block;
+			}
+		}
+	}
+}
+</style>

--- a/src/components/Tabs/OutputTab.vue
+++ b/src/components/Tabs/OutputTab.vue
@@ -1,0 +1,45 @@
+<template>
+	<div>
+		<div class="command-output" v-html="formattedOutput"></div>
+	</div>
+</template>
+
+<script>
+import AnsiToHtml from 'ansi-to-html'
+
+export default {
+	name: 'OutputTab',
+	computed: {
+		formattedOutput() { return this.ansiToHtml.toHtml(this.$request.commandOutput) }
+	},
+	created() {
+		this.ansiToHtml = new AnsiToHtml({
+			fg: '#c7c7c7',
+			bg: '#000000',
+			escapeXML: true,
+			colors: {
+				0: '#000000', 1: '#c91b00', 2: '#00c200', 3: '#c7c400', 4: '#0225c7', 5: '#c930c7', 6: '#00c5c7',
+				7: '#c7c7c7', 8: '#676767', 9: '#ff6d67', 10: '#5ff967', 11: '#fefb67', 12: '#6871ff', 13: '#ff76ff',
+				14: '#5ffdff', 15: '#feffff'
+			}
+		})
+	}
+}
+</script>
+
+<style lang="scss">
+@import '../../mixins.scss';
+
+.command-output {
+	background: #333;
+	border-radius: 6px;
+	font-family: Menlo, monospace;
+	overflow: auto;
+	padding: 16px 12px;
+	white-space: pre;
+
+	@include dark {
+		background: #111;
+	}
+}
+</style>

--- a/src/components/Tabs/OutputTab.vue
+++ b/src/components/Tabs/OutputTab.vue
@@ -10,7 +10,7 @@ import AnsiToHtml from 'ansi-to-html'
 export default {
 	name: 'OutputTab',
 	computed: {
-		formattedOutput() { return this.ansiToHtml.toHtml(this.$request.commandOutput) }
+		formattedOutput() { return this.ansiToHtml.toHtml(this.$request.commandOutput || '') }
 	},
 	created() {
 		this.ansiToHtml = new AnsiToHtml({

--- a/src/features/request.js
+++ b/src/features/request.js
@@ -355,8 +355,8 @@ export default class Request
 	processCommand() {
 		this.commandLine = ''
 
-		this.commandLine += (Object.values(this.commandArguments) || []).filter(val => val).join(' ')
-		this.commandLine += (Object.entries(this.commandOptions) || []).reduce((line, [ option, value ]) => {
+		this.commandLine += (Object.values(this.commandArguments || {})).filter(val => val).join(' ')
+		this.commandLine += (Object.entries(this.commandOptions || {})).reduce((line, [ option, value ]) => {
 			return line + (value === true ? ` --${option}` : ` --${option}=${value}`)
 		}, '')
 

--- a/src/features/requests-search.js
+++ b/src/features/requests-search.js
@@ -12,7 +12,8 @@ export default class RequestsSearch
 			{ tag: 'method', validate: val => [ 'get', 'post', 'put', 'patch', 'delete', 'head' ].includes(val) },
 			{ tag: 'status', validate: val => val >= 100 && val < 600 },
 			{ tag: 'time' },
-			{ tag: 'received', validate: val => moment(val).isValid() }
+			{ tag: 'received', validate: val => moment(val).isValid() },
+			{ tag: 'type', validate: val => [ 'command', 'request' ].includes(val) }
 		]
 
 		this.shown = false
@@ -43,7 +44,9 @@ export default class RequestsSearch
 			return tags
 		}, {})
 
-		this.requests.setQuery(terms.length || Object.keys(tags).length ? { 'uri[]': terms, ...tags } : {})
+		this.requests.setQuery(
+			terms.length || Object.keys(tags).length ? { 'uri[]': terms, 'name[]': terms, ...tags } : {}
+		)
 
 		this.requests.returnLatest().then(latest => {
 			this.requests.returnPrevious(9, latest.id).then(previous => {

--- a/src/features/requests.js
+++ b/src/features/requests.js
@@ -147,6 +147,15 @@ export default class Requests
 		this.query = query
 	}
 
+	withQuery(query, callback) {
+		let previousQuery = this.query
+		this.query = query
+
+		callback()
+
+		this.query = previousQuery
+	}
+
 	load(uri, configure, exclusive = false) {
 		if (exclusive) return this.loadExclusive(uri, configure)
 

--- a/src/features/settings.js
+++ b/src/features/settings.js
@@ -1,11 +1,14 @@
+import Extension from '../platform/extension'
+
 import extend from 'just-extend'
 import mapValues from 'just-map-values'
 
 export default class Settings
 {
-	constructor(store, requests) {
+	constructor(store, requests, platform) {
 		this.store = store
 		this.requests = requests
+		this.platform = platform
 
 		this.shown = false
 		this.settings = {}
@@ -31,6 +34,8 @@ export default class Settings
 
 	save() {
 		this.store.set('settings', this.settings)
+
+		this.platform.settingsChanged()
 	}
 
 	load() {
@@ -48,7 +53,8 @@ export default class Settings
 			global: {
 				appearance: 'auto',
 				editor: null,
-				showIncomingRequests: true
+				showIncomingRequests: true,
+				hideCommandTypeRequests: this.platform instanceof Extension
 			},
 			site: {
 				localPathMap: { real: null, local: null }

--- a/src/main.js
+++ b/src/main.js
@@ -18,11 +18,11 @@ import Settings from './features/settings'
 import TextFilters from './features/text-filters'
 import UpdateNotification from './features/update-notification'
 
+let $platform = Extension.runningAsExtension() ? new Extension : new Standalone
+
 let $store = new LocalStore
 let $requests = new Requests($store)
-let $settings = new Settings($store, $requests)
-
-let $platform = Extension.runningAsExtension() ? new Extension : new Standalone
+let $settings = new Settings($store, $requests, $platform)
 
 let $authentication = new Authentication($requests)
 let $editorLinks = new EditorLinks($settings)


### PR DESCRIPTION
- added support for "command" type requests
- command-specific metadata in requests list including command name, passed arguments/options and exit code
- command sidebar shows applied arguments and options (including defaults)
- new output tab showing command output (when collected)
- added support for searching by request type and command name
- added "hide commands in requests list" setting
- added polling for command-type requests in extension mode (only active when "hide commands" id disabled)
- server-side PR - https://github.com/itsgoingd/clockwork/pull/361

<img width="1346" alt="Screenshot 2019-11-09 at 22 37 22" src="https://user-images.githubusercontent.com/821582/68535355-8bb6ec00-0341-11ea-8711-b151ff3bd6d1.png">
