### PR TITLE
Views tab timeline

### DIFF
--- a/src/components/RequestDetails.vue
+++ b/src/components/RequestDetails.vue
@@ -136,7 +136,7 @@ export default {
 				redis: this.$request?.redisCommands?.length > 0,
 				queue: this.$request?.queueJobs?.length > 0,
 				events: this.$request?.events?.length > 0,
-				views: this.$request?.views?.length > 0,
+				views: this.$request?.viewsData?.length > 0,
 				emails: this.$request?.emails?.length > 0,
 				routes: this.$request?.routes?.length > 0,
 				output: this.$request?.commandOutput?.length > 0

--- a/src/components/Tabs/Performance/Timeline.vue
+++ b/src/components/Tabs/Performance/Timeline.vue
@@ -36,7 +36,11 @@
 						</div>
 					</td>
 					<td class="timeline-duration">{{item.durationRounded}} ms</td>
-					<td class="timeline-description">{{item.description}}</td>
+					<td class="timeline-description">
+						<slot name="table-description" :item="item">
+							{{item.description}}
+						</slot>
+					</td>
 				</tr>
 			</template>
 		</details-table>

--- a/src/components/Tabs/Performance/Timeline.vue
+++ b/src/components/Tabs/Performance/Timeline.vue
@@ -16,7 +16,7 @@
 			</span>
 		</div>
 
-		<details-table :columns="['Timeline', 'Duration', 'Description']" :items="$request.timeline" :filter="filter" filter-example="database query duration:>50">
+		<details-table :columns="['Timeline', 'Duration', 'Description']" :items="items" :filter="filter" filter-example="database query duration:>50">
 			<template slot="header" slot-scope="{ filter }">
 				<th>Timeline</th>
 				<th class="timeline-duration">Duration</th>
@@ -51,6 +51,7 @@ import Filter from '../../../features/filter'
 export default {
 	name: 'Timeline',
 	components: { DetailsTable },
+	props: [ 'items' ],
 	data: () => ({
 		view: 'chart',
 

--- a/src/components/Tabs/PerformanceTab.vue
+++ b/src/components/Tabs/PerformanceTab.vue
@@ -28,7 +28,7 @@
 				<a class="performance-tab" :class="{ 'active': isTabActive('profiler') }" href="#" @click.prevent="showTab('profiler')">Profiler</a>
 			</div>
 
-			<timeline v-show="isTabActive('timeline')"></timeline>
+			<timeline :items="$request.timeline" v-show="isTabActive('timeline')"></timeline>
 			<profiler v-show="isTabActive('profiler')"></profiler>
 		</div>
 	</div>

--- a/src/components/Tabs/ViewsTab.vue
+++ b/src/components/Tabs/ViewsTab.vue
@@ -1,21 +1,26 @@
 <template>
 	<div>
-		<timeline :items="$request.viewsData"></timeline>
+		<timeline :items="$request.viewsData">
+			<template slot="table-description" slot-scope="{ item }">
+				<div class="views-view-name">{{ item.description }}</div>
+				<pretty-print :data="item.data.data" v-if="item.data && item.data.data"></pretty-print>
+			</template>
+		</timeline>
 	</div>
 </template>
 
 <script>
 import Timeline from './Performance/Timeline'
-import DetailsTable from '../UI/DetailsTable'
 import PrettyPrint from '../UI/PrettyPrint'
-
-import Filter from '../../features/filter'
 
 export default {
 	name: 'ViewsTab',
-	components: { DetailsTable, PrettyPrint, Timeline },
-	data: () => ({
-		filter: new Filter([ { tag: 'name' } ])
-	})
+	components: { PrettyPrint, Timeline }
 }
 </script>
+
+<style lang="scss">
+.views-view-name {
+	margin-bottom: 3px;
+}
+</style>

--- a/src/components/Tabs/ViewsTab.vue
+++ b/src/components/Tabs/ViewsTab.vue
@@ -3,7 +3,7 @@
 		<timeline :items="$request.viewsData">
 			<template slot="table-description" slot-scope="{ item }">
 				<div class="views-view-name">{{ item.description }}</div>
-				<pretty-print :data="item.data.data" v-if="item.data && item.data.data"></pretty-print>
+				<pretty-print :data="item.data.data" v-if="item.data.data"></pretty-print>
 			</template>
 		</timeline>
 	</div>

--- a/src/components/Tabs/ViewsTab.vue
+++ b/src/components/Tabs/ViewsTab.vue
@@ -1,17 +1,11 @@
 <template>
 	<div>
-		<details-table :columns="['Name', 'Data']" :items="$request.views" :filter="filter" filter-example="&quot;Mike Jones&quot; name:welcome">
-			<template slot="body" slot-scope="{ items }">
-				<tr v-for="view, index in items" :key="`${$request.id}-${index}`">
-					<td>{{view.name}}</td>
-					<td><pretty-print :data="view.data"></pretty-print></td>
-				</tr>
-			</template>
-		</details-table>
+		<timeline :items="$request.viewsData"></timeline>
 	</div>
 </template>
 
 <script>
+import Timeline from './Performance/Timeline'
 import DetailsTable from '../UI/DetailsTable'
 import PrettyPrint from '../UI/PrettyPrint'
 
@@ -19,7 +13,7 @@ import Filter from '../../features/filter'
 
 export default {
 	name: 'ViewsTab',
-	components: { DetailsTable, PrettyPrint },
+	components: { DetailsTable, PrettyPrint, Timeline },
 	data: () => ({
 		filter: new Filter([ { tag: 'name' } ])
 	})

--- a/src/features/request.js
+++ b/src/features/request.js
@@ -29,7 +29,7 @@ export default class Request
 		this.sessionData = this.createKeypairs(this.sessionData)
 		this.performanceMetrics = this.processPerformanceMetrics(this.performanceMetrics)
 		this.timeline = this.processTimeline(this.timelineData)
-		this.views = this.processViews(this.viewsData)
+		this.viewsData = this.processViews(this.viewsData)
 		this.userData = this.processUserData(this.userData)
 		this.processCommand()
 		this.processQueueJob()
@@ -358,9 +358,13 @@ export default class Request
 	}
 
 	processViews(data) {
-		if (! (data instanceof Object)) return []
+		let views = Object.values(data).forEach(view => {
+			if (view.data && view.data.name) view.description = view.data.name
 
-		return Object.values(data).filter(view => view.data instanceof Object).map(view => view.data)
+			return view
+		})
+
+		return this.processTimeline(data)
 	}
 
 	processUserData(tabs) {

--- a/src/features/request.js
+++ b/src/features/request.js
@@ -364,6 +364,8 @@ export default class Request
 			view.data.data = view.data.data instanceof Object && Object.keys(view.data.data).filter(key => key != '__type__').length
 				? view.data.data : undefined
 
+			if (view.data.memoryUsage) view.description += ` (${this.formatBytes(view.data.memoryUsage)})`
+
 			return view
 		})
 

--- a/src/features/request.js
+++ b/src/features/request.js
@@ -359,7 +359,10 @@ export default class Request
 
 	processViews(data) {
 		let views = Object.values(data).forEach(view => {
-			if (view.data && view.data.name) view.description = view.data.name
+			view.data = view.data || {}
+			view.description = view.data.name || view.description
+			view.data.data = view.data.data instanceof Object && Object.keys(view.data.data).filter(key => key != '__type__').length
+				? view.data.data : undefined
 
 			return view
 		})


### PR DESCRIPTION
- reworked views tab to use a timeline view (same as performance tab)
- don't show empty view data
- added support for memory usage
- server-side PR - https://github.com/itsgoingd/clockwork/pull/365

<img width="1325" alt="Screenshot 2019-12-26 at 01 11 33" src="https://user-images.githubusercontent.com/821582/71451846-1d59ac00-277e-11ea-81d1-f0fae2dd078d.png">
