### PR TITLE
Settings saving improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 4.1.1 (unreleased)
 
+- added support for the "chrome.storage" api as a fall-back persistent settings storage if localStorage is not available
+- improved behavior if we have no persistent storage, warning is now shown in the settings modal and what's new message is no longer shown (reported by ci_trex, thanks!)
 - fixed pretty printing showing objects with empty string keys as infinitely recursive (reported by mahagr, thanks!)
 
 4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - added support for the "chrome.storage" api as a fall-back persistent settings storage if localStorage is not available
 - improved behavior if we have no persistent storage, warning is now shown in the settings modal and what's new message is no longer shown (reported by ci_trex, thanks!)
+- fixed authentication UI might not be shown as expected when running as an extension
 - fixed pretty printing showing objects with empty string keys as infinitely recursive (reported by mahagr, thanks!)
 
 4.1

--- a/platforms/chrome/manifest.json
+++ b/platforms/chrome/manifest.json
@@ -21,6 +21,7 @@
 
 	"permissions": [
 		"cookies",
+		"storage",
 		"tabs",
 		"webNavigation",
 		"webRequest",

--- a/platforms/firefox/manifest.json
+++ b/platforms/firefox/manifest.json
@@ -19,6 +19,7 @@
 
 	"permissions": [
 		"cookies",
+		"storage",
 		"tabs",
 		"webNavigation",
 		"webRequest",

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,8 +1,8 @@
 <template>
 	<div class="application split-view" :class="appearance">
-		<requests-list v-show="! $store.data.requestsListCollapsed"></requests-list>
+		<requests-list v-show="! $settings.global.requestsListCollapsed"></requests-list>
 		<request-details></request-details>
-		<request-sidebar v-show="! $store.data.requestSidebarCollapsed"></request-sidebar>
+		<request-sidebar v-show="! $settings.global.requestSidebarCollapsed"></request-sidebar>
 
 		<whats-new></whats-new>
 	</div>

--- a/src/components/Details/MessagesOverlay.vue
+++ b/src/components/Details/MessagesOverlay.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="messages-overlay">
-		<parent-request compact="true" v-show="$store.data.requestSidebarCollapsed"></parent-request>
-		<exception-section compact="true" v-show="$store.data.requestSidebarCollapsed"></exception-section>
+		<parent-request compact="true" v-show="$settings.global.requestSidebarCollapsed"></parent-request>
+		<exception-section compact="true" v-show="$settings.global.requestSidebarCollapsed"></exception-section>
 
 		<div class="update-notification" v-if="updateNotification">
 			<span>

--- a/src/components/Details/WhatsNew.vue
+++ b/src/components/Details/WhatsNew.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="whats-new" v-if="shown">
+	<div class="whats-new" v-if="$whatsNew.show">
 		<div class="whats-new-content">
 			<h1>Clockwork has just been updated!</h1>
 
@@ -29,18 +29,13 @@ import WhatsNew from '../../features/whats-new'
 export default {
 	name: 'WhatsNew',
 	computed: {
-		shown() {
-			return this.$settings.global.seenReleaseNotesVersion != WhatsNew.latestRelease.version
-		},
-
 		release() {
 			return WhatsNew.latestRelease
 		}
 	},
 	methods: {
 		close() {
-			this.$settings.global.seenReleaseNotesVersion = WhatsNew.latestRelease.version
-			this.$settings.save()
+			this.$whatsNew.seen()
 		}
 	}
 }

--- a/src/components/RequestDetails.vue
+++ b/src/components/RequestDetails.vue
@@ -3,10 +3,10 @@
 
 		<div class="details-header">
 			<div class="icons">
-				<a href="#" title="Toggle requests" v-show="! $store.data.requestsListCollapsed" @click="toggleRequestsList">
+				<a href="#" title="Toggle requests" v-show="! $settings.global.requestsListCollapsed" @click="toggleRequestsList">
 					<font-awesome-icon icon="outdent"></font-awesome-icon>
 				</a>
-				<a href="#" title="Toggle requests" v-show="$store.data.requestsListCollapsed" @click="toggleRequestsList">
+				<a href="#" title="Toggle requests" v-show="$settings.global.requestsListCollapsed" @click="toggleRequestsList">
 					<font-awesome-icon icon="indent"></font-awesome-icon>
 				</a>
 				<a href="#" title="Search requests" @click="$requestsSearch.toggle()">
@@ -30,17 +30,17 @@
 			</div>
 
 			<div class="icons">
-				<a href="#" title="Preserve log" @click="togglePreserveLog" v-show="$store.data.requestSidebarCollapsed">
-					<font-awesome-icon :icon="$store.data.preserveLog ? 'circle' : ['far', 'circle']"></font-awesome-icon>
+				<a href="#" title="Preserve log" @click="togglePreserveLog" v-show="$settings.global.requestSidebarCollapsed">
+					<font-awesome-icon :icon="$settings.global.preserveLog ? 'circle' : ['far', 'circle']"></font-awesome-icon>
 				</a>
-				<a href="#" title="Clear" @click="clear" v-show="$store.data.requestSidebarCollapsed">
+				<a href="#" title="Clear" @click="clear" v-show="$settings.global.requestSidebarCollapsed">
 					<font-awesome-icon icon="ban"></font-awesome-icon>
 				</a>
 				<a href="#" title="Settings" @click="toggleSettingsModal" :class="{'active': $settings.shown}">
 					<font-awesome-icon icon="cog"></font-awesome-icon>
 				</a>
 				<a href="#" title="Toggle sidebar" @click="toggleRequestSidebar">
-					<font-awesome-icon :icon="$store.data.requestSidebarCollapsed ? 'outdent' : 'indent'"></font-awesome-icon>
+					<font-awesome-icon :icon="$settings.global.requestSidebarCollapsed ? 'outdent' : 'indent'"></font-awesome-icon>
 				</a>
 			</div>
 		</div>
@@ -149,13 +149,16 @@ export default {
 			this.global.showIncomingRequests = false
 		},
 		toggleRequestsList() {
-			this.$store.set('requestsListCollapsed', ! this.$store.get('requestsListCollapsed'))
+			this.$settings.global.requestsListCollapsed = ! this.$settings.global.requestsListCollapsed
+			this.$settings.save()
 		},
 		toggleRequestSidebar() {
-			this.$store.set('requestSidebarCollapsed', ! this.$store.get('requestSidebarCollapsed'))
+			this.$settings.global.requestSidebarCollapsed = ! this.$settings.global.requestSidebarCollapsed
+			this.$settings.save()
 		},
 		togglePreserveLog() {
-			this.$store.set('preserveLog', ! this.$store.get('preserveLog'))
+			this.$settings.global.preserveLog = ! this.$settings.global.preserveLog
+			this.$settings.save()
 		},
 		toggleSettingsModal() {
 			this.$settings.toggle()

--- a/src/components/RequestSidebar.vue
+++ b/src/components/RequestSidebar.vue
@@ -1,5 +1,5 @@
 <template>
-	<div :class="{ 'request-sidebar': true, 'large': $store.data.requestsListCollapsed }">
+	<div :class="{ 'request-sidebar': true, 'large': $settings.global.requestsListCollapsed }">
 
 		<div class="sidebar-header">
 			<div class="sidebar-title">
@@ -22,7 +22,7 @@
 					<font-awesome-icon icon="link"></font-awesome-icon>
 				</a>
 				<a href="#" title="Preserve log" @click="togglePreserveLog">
-					<font-awesome-icon :icon="$store.data.preserveLog ? 'circle' : ['far', 'circle']"></font-awesome-icon>
+					<font-awesome-icon :icon="$settings.global.preserveLog ? 'circle' : ['far', 'circle']"></font-awesome-icon>
 				</a>
 				<a href="#" title="Clear" @click="clear">
 					<font-awesome-icon icon="ban"></font-awesome-icon>
@@ -61,7 +61,8 @@ export default {
 	components: { CommandTab, ExceptionSection, ParentRequest, QueueJobTab, RequestTab, TestTab },
 	methods: {
 		togglePreserveLog() {
-			this.$store.set('preserveLog', ! this.$store.get('preserveLog'))
+			this.$settings.global.preserveLog = ! this.$settings.global.preserveLog
+			this.$settings.save()
 		},
 		clear() { this.$requests.clear() }
 	}

--- a/src/components/RequestsList.vue
+++ b/src/components/RequestsList.vue
@@ -1,5 +1,5 @@
 <template>
-	<div :class="{ 'split-view-pane split-view-requests': true, 'large': $store.data.requestSidebarCollapsed }">
+	<div :class="{ 'split-view-pane split-view-requests': true, 'large': $settings.global.requestSidebarCollapsed }">
 		<table class="requests-header" id="requests-header">
 			<thead>
 				<tr>
@@ -76,7 +76,7 @@
 							<small>{{request.testName}}</small>
 						</template>
 						<template v-else>
-							<small v-if="$store.data.requestSidebarCollapsed">{{request.controller}}</small>
+							<small v-if="$settings.global.requestSidebarCollapsed">{{request.controller}}</small>
 							<small v-else>{{request.controller | shortClass}}</small>
 						</template>
 					</td>
@@ -161,11 +161,11 @@ export default {
 			})
 		},
 		shouldShowFirstRequest() {
-			return ! this.$store.get('preserveLog')
+			return ! this.$settings.global.preserveLog
 				&& (! this.$request || ! this.$requests.findId(this.$request.id))
 		},
 		shouldShowIncomingRequest() {
-			return this.$store.get('preserveLog')
+			return this.$settings.global.preserveLog
 				&& (! this.$request || (this.$settings.global.showIncomingRequests && this.global.showIncomingRequests))
 		}
 	},

--- a/src/components/RequestsList.vue
+++ b/src/components/RequestsList.vue
@@ -192,6 +192,16 @@ export default {
 				let lastPageRequestIndex = this.$requests.all().indexOf(lastPageRequest)
 				this.global.showIncomingRequests = this.$requests.all().slice(lastPageRequestIndex).includes(request)
 			}
+		},
+
+		'$request.loading': {
+			handler(loading) {
+				if (loading) return
+
+				if (this.$request?.error?.error == 'requires-authentication') {
+					this.$authentication.request(this.$request.error.message, this.$request.error.requires)
+				}
+			}
 		}
 	}
 }

--- a/src/components/Settings/SettingsModal.vue
+++ b/src/components/Settings/SettingsModal.vue
@@ -8,7 +8,7 @@
 					<a href="#" @click.prevent="showPersistWarning = true">More info</a>
 				</div>
 				<div class="warning-details" v-if="showPersistWarning">
-					Clockwork uses the "local storage" api to persist your settings. Please make sure to allow access to "local storage" for this app.
+					Clockwork uses the "local storage" api to persist your settings. Please make sure the access to "local storage" is allowed for this app.
 				</div>
 			</div>
 

--- a/src/components/Settings/SettingsModal.vue
+++ b/src/components/Settings/SettingsModal.vue
@@ -1,6 +1,17 @@
 <template>
 	<transition name="settings">
 		<div class="settings-modal" v-show="$settings.shown">
+			<div class="settings-warning" v-if="! $settings.persistent">
+				<div class="warning-text">
+					<span class="warning-label">Warning</span>
+					<span>Settings can not be saved.</span>
+					<a href="#" @click.prevent="showPersistWarning = true">More info</a>
+				</div>
+				<div class="warning-details" v-if="showPersistWarning">
+					Clockwork uses the "local storage" api to persist your settings. Please make sure to allow access to "local storage" for this app.
+				</div>
+			</div>
+
 			<div class="controls-group">
 				<label for="settings-editor">Appearance</label>
 
@@ -97,6 +108,7 @@
 export default {
 	name: 'SettingsModal',
 	data: () => ({
+		showPersistWarning: false
 	}),
 	methods: {
 		setAppearance(appearance) {
@@ -122,7 +134,7 @@ export default {
 	font-size: 13px;
 	left: 5%;
 	max-width: 600px;
-	padding: 32px 35px 1px;
+	padding: 30px 35px 1px;
 	position: absolute;
 	text-align: left;
 	top: 0;
@@ -176,7 +188,8 @@ export default {
 
 		&[type="checkbox"] {
 			height: auto;
-			margin-right: 3px;
+			margin: 0 3px 0 0;
+			vertical-align: middle;
 		}
 	}
 
@@ -207,9 +220,14 @@ export default {
 
 	.controls-checkbox {
 		display: inline-block;
-		margin-bottom: 5px;
+		margin-bottom: 10px;
+		margin-top: 0;
 		text-align: left;
 		width: 100%;
+
+		&:last-child {
+			margin: 0;
+		}
 	}
 
 	.appearance-controls {
@@ -244,6 +262,53 @@ export default {
 			}
 		}
 	}
+
+	.settings-warning {
+		background: rgb(255, 235, 235);
+		color: rgb(197, 31, 36);
+		margin-left: -35px;
+		padding: 10px 15px;
+		width: calc(100% + 70px);
+
+		.warning-text {
+			display: flex;
+		}
+
+		.warning-details {
+			font-size: 90%;
+			margin-top: 5px;
+		}
+
+		.warning-label {
+			border: 1px solid hsl(358, 55%, 70%);
+			border-radius: 6px;
+			color: hsl(358, 55%, 70%);
+			font-size: 90%;
+			font-weight: 500;
+			margin-right: 5px;
+			text-transform: uppercase;
+			padding: 1px 3px;
+		}
+
+		a {
+			color: hsl(358, 55%, 70%);
+			margin-left: auto;
+		}
+
+		@include dark {
+			background: hsl(0, 100%, 11%);
+			color: rgb(237, 121, 122);
+
+			.warning-label {
+				border: 1px solid hsl(359, 38%, 62%);
+				color: hsl(359, 38%, 62%);
+			}
+
+			a {
+				color: hsl(359, 38%, 62%);
+			}
+		}
+	}
 }
 
 .settings-enter-active, .settings-leave-active {
@@ -251,6 +316,6 @@ export default {
 }
 
 .settings-enter, .settings-leave-to {
-	top: -400px;
+	top: -500px;
 }
 </style>

--- a/src/components/Settings/SettingsModal.vue
+++ b/src/components/Settings/SettingsModal.vue
@@ -4,7 +4,7 @@
 			<div class="settings-warning" v-if="! $settings.persistent">
 				<div class="warning-text">
 					<span class="warning-label">Warning</span>
-					<span>Settings can not be saved.</span>
+					<span>Settings can't be saved.</span>
 					<a href="#" @click.prevent="showPersistWarning = true">More info</a>
 				</div>
 				<div class="warning-details" v-if="showPersistWarning">

--- a/src/components/UI/SidebarSection.vue
+++ b/src/components/UI/SidebarSection.vue
@@ -42,10 +42,14 @@ export default {
 		filter: new Filter([ { tag: 'name' } ])
 	}),
 	computed: {
-		expanded() { return this.$store.get(`sidebarSection.${this.name}`, true) }
+		expanded() {
+			return this.$settings.global.requestSidebarCollapsedSections[this.name] !== false
+		}
 	},
 	methods: {
-		toggle() { this.$store.set(`sidebarSection.${this.name}`, ! this.expanded) }
+		toggle() {
+			this.$settings.global.requestSidebarCollapsedSections[this.name] = ! this.expanded
+		}
 	}
 }
 </script>

--- a/src/features/local-store.js
+++ b/src/features/local-store.js
@@ -3,6 +3,8 @@ import extend from 'just-extend'
 export default class LocalStore
 {
 	constructor() {
+		this.persistent = true
+
 		this.load()
 	}
 
@@ -20,7 +22,9 @@ export default class LocalStore
 	load() {
 		try {
 			this.data = JSON.parse(localStorage.getItem('clockwork'))
-		} catch (e) {}
+		} catch (e) {
+			this.persistent = false
+		}
 
 		if (! (this.data instanceof Object)) this.data = {}
 

--- a/src/features/local-store.js
+++ b/src/features/local-store.js
@@ -1,47 +1,74 @@
-import extend from 'just-extend'
-
 export default class LocalStore
 {
 	constructor() {
-		this.persistent = true
+		this.backend = null
+
+		if (this.isLocalStorageAvailable()) {
+			this.backend = 'local-storage'
+		} else if (this.isBrowserStorageAvailable()) {
+			this.backend = 'browser-storage'
+		}
+
+		this.persistent = !! this.backend
+		this.data = null
 
 		this.load()
 	}
 
-	get(key, defaultValue) {
+	async get(key, defaultValue) {
+		await this.load()
+
 		if (this.data[key] == undefined) this.set(key, defaultValue)
 
 		return this.data[key]
 	}
 
-	set(key, value) {
+	async set(key, value) {
+		await this.load()
+
 		this.data[key] = value
 		this.save()
 	}
 
 	load() {
-		try {
-			this.data = JSON.parse(localStorage.getItem('clockwork'))
-		} catch (e) {
-			this.persistent = false
-		}
+		if (this.data) return Promise.resolve()
 
-		if (! (this.data instanceof Object)) this.data = {}
+		return new Promise(accept => {
+			if (this.backend == 'local-storage') {
+				this.loaded(accept, localStorage.getItem('clockwork'))
+			} else if (this.backend == 'browser-storage') {
+				(window.browser || window.chrome).storage.local.get(['clockwork'], data => {
+					this.loaded(accept, data.clockwork)
+				})
+			} else {
+				this.loaded(accept)
+			}
+		})
+	}
 
-		this.data = extend({}, this.defaults(), this.data)
+	loaded(accept, json) {
+		try { this.data = JSON.parse(json) } catch (e) {}
+
+		this.data = this.data instanceof Object ? this.data : {}
+
+		accept()
 	}
 
 	save() {
-		try {
-			localStorage.setItem('clockwork', JSON.stringify(this.data))
-		} catch (e) {}
+		if (this.backend == 'local-storage') {
+			try { localStorage.setItem('clockwork', JSON.stringify(this.data)) } catch (e) {}
+		} else if (this.backend == 'browser-storage') {
+			(window.browser || window.chrome).storage.local.set({ clockwork: JSON.stringify(this.data) })
+		}
 	}
 
-	defaults() {
-		return {
-			preserveLog: true,
-			requestsListCollapsed: false,
-			requestSidebarCollapsed: false
-		}
+	isLocalStorageAvailable() {
+		try { localStorage } catch (e) { return false }
+
+		return true
+	}
+
+	isBrowserStorageAvailable() {
+		return (window.browser && browser.storage) || (window.chrome && chrome.storage)
 	}
 }

--- a/src/features/local-store.js
+++ b/src/features/local-store.js
@@ -18,7 +18,7 @@ export default class LocalStore
 	async get(key, defaultValue) {
 		await this.load()
 
-		if (this.data[key] == undefined) this.set(key, defaultValue)
+		if (this.data[key] == undefined) await this.set(key, defaultValue)
 
 		return this.data[key]
 	}

--- a/src/features/requests.js
+++ b/src/features/requests.js
@@ -3,15 +3,12 @@ import URI from 'urijs'
 
 export default class Requests
 {
-	constructor(store) {
-		this.store = store
+	constructor() {
+		this.settings = null
 		this.items = []
 
-		this.tokens = this.store.get('requests.tokens')
 		this.query = {}
 		this.exclusive = {}
-
-		if (! (this.tokens instanceof Object)) this.tokens = {}
 	}
 
 	// returns all requests up to the first placeholder, or everything if there are no placeholders
@@ -164,8 +161,8 @@ export default class Requests
 	}
 
 	setAuthenticationToken(token) {
-		this.tokens[this.remoteUrl] = token
-		this.store.set('requests.tokens', this.tokens)
+		this.settings.site.authToken = token
+		this.settings.save()
 	}
 
 	setQuery(query) {
@@ -185,7 +182,7 @@ export default class Requests
 		if (exclusive) return this.loadExclusive(uri, configure)
 
 		let url = URI(`${this.remoteUrl}${uri}`).addQuery(this.query).toString()
-		let headers = Object.assign({}, this.remoteHeaders, { 'X-Clockwork-Auth': this.tokens[this.remoteUrl] })
+		let headers = Object.assign({}, this.remoteHeaders, { 'X-Clockwork-Auth': this.settings.site.authToken })
 
 		return configure(this.client('GET', url, {}, headers).then(data => {
 			if (! data) return []

--- a/src/features/settings.js
+++ b/src/features/settings.js
@@ -10,8 +10,10 @@ export default class Settings
 		this.requests = requests
 		this.platform = platform
 
+		this.requests.settings = this
+
 		this.shown = false
-		this.settings = {}
+		this.settings = this.defaults()
 
 		this.load()
 	}
@@ -42,9 +44,9 @@ export default class Settings
 		this.platform.settingsChanged()
 	}
 
-	load() {
+	async load() {
 		let defaults = this.defaults()
-		let settings = this.store.get('settings', {})
+		let settings = await this.store.get('settings', {})
 
 		this.settings = {
 			global: extend(true, defaults.global, settings.global || {}),
@@ -61,8 +63,13 @@ export default class Settings
 				hideCommandTypeRequests: this.platform instanceof Extension,
 				hideQueueJobTypeRequests: this.platform instanceof Extension,
 				hideTestTypeRequests: this.platform instanceof Extension,
-				timelineHiddenTags: {},
-				seenReleaseNotesVersion: null
+				ignoredUpdateNotifications: {},
+				preserveLog: true,
+				requestsListCollapsed: false,
+				requestSidebarCollapsed: false,
+				requestSidebarCollapsedSections: {},
+				seenReleaseNotesVersion: null,
+				timelineHiddenTags: {}
 			},
 			site: {
 				localPathMap: { real: null, local: null }

--- a/src/features/settings.js
+++ b/src/features/settings.js
@@ -28,6 +28,10 @@ export default class Settings
 		return this.settings.site[this.requests.remoteUrl]
 	}
 
+	get persistent() {
+		return this.store.persistent
+	}
+
 	toggle() {
 		this.shown = ! this.shown
 	}

--- a/src/features/update-notification.js
+++ b/src/features/update-notification.js
@@ -1,13 +1,13 @@
 export default class UpdateNotification
 {
-	constructor(store) {
-		this.store = store
+	constructor(settings) {
+		this.settings = settings
 
 		this.serverVersion = null
 	}
 
 	get ignoredUpdates() {
-		return this.store.get('update-notification.ignored-updates') || {}
+		return this.settings.global.ignoredUpdateNotifications || {}
 	}
 
 	latest() {

--- a/src/features/whats-new.js
+++ b/src/features/whats-new.js
@@ -1,5 +1,20 @@
 export default class WhatsNew
 {
+	constructor(settings) {
+		this.settings = settings
+	}
+
+	get show() {
+		// show the what's new content only when not already seen and the seen state can be persisted
+		return this.settings.global.seenReleaseNotesVersion != WhatsNew.latestRelease.version
+			&& this.settings.persistent
+	}
+
+	seen() {
+		this.settings.global.seenReleaseNotesVersion = WhatsNew.latestRelease.version
+		this.settings.save()
+	}
+
 	static get latestRelease() {
 		return WhatsNew.releases[0]
 	}

--- a/src/main.js
+++ b/src/main.js
@@ -22,7 +22,7 @@ import WhatsNew from './features/whats-new'
 let $platform = Extension.runningAsExtension() ? new Extension : new Standalone
 
 let $store = new LocalStore
-let $requests = new Requests($store)
+let $requests = new Requests
 let $settings = new Settings($store, $requests, $platform)
 
 let $authentication = new Authentication($requests)
@@ -30,7 +30,7 @@ let $editorLinks = new EditorLinks($settings)
 let $profiler = new Profiler($requests, $platform)
 let $requestsSearch = new RequestsSearch($requests)
 let $textFilters = new TextFilters
-let $updateNotification = new UpdateNotification($store)
+let $updateNotification = new UpdateNotification($settings)
 let $whatsNew = new WhatsNew($settings)
 
 let global = {

--- a/src/main.js
+++ b/src/main.js
@@ -17,6 +17,7 @@ import RequestsSearch from './features/requests-search'
 import Settings from './features/settings'
 import TextFilters from './features/text-filters'
 import UpdateNotification from './features/update-notification'
+import WhatsNew from './features/whats-new'
 
 let $platform = Extension.runningAsExtension() ? new Extension : new Standalone
 
@@ -30,9 +31,10 @@ let $profiler = new Profiler($requests, $platform)
 let $requestsSearch = new RequestsSearch($requests)
 let $textFilters = new TextFilters
 let $updateNotification = new UpdateNotification($store)
+let $whatsNew = new WhatsNew($settings)
 
 let global = {
-	$requests, $platform, $authentication, $profiler, $requestsSearch, $settings, $store, $updateNotification,
+	$requests, $platform, $authentication, $profiler, $requestsSearch, $settings, $store, $updateNotification, $whatsNew,
 	$request: null, activeTab: 'performance', showIncomingRequests: true, defaultAppearance: 'light'
 }
 

--- a/src/platform/extension.js
+++ b/src/platform/extension.js
@@ -14,7 +14,6 @@ export default class Extension
 		this.requests = global.$requests
 		this.profiler = global.$profiler
 		this.settings = global.$settings
-		this.store = global.$store
 		this.updateNotification = global.$updateNotification
 
 		this.useProperTheme()
@@ -120,7 +119,7 @@ export default class Extension
 			if (message.action !== 'navigationStarted') return;
 
 			// preserve log is enabled
-			if (this.store.get('preserveLog')) return
+			if (this.settings.global.preserveLog) return
 
 			// navigation event from a different tab
 			if (message.details.tabId != this.api.devtools.inspectedWindow.tabId) return

--- a/src/platform/standalone.js
+++ b/src/platform/standalone.js
@@ -9,7 +9,7 @@ export default class Standalone
 		this.requests = global.$requests
 		this.authentication = global.$authentication
 		this.profiler = global.$profiler
-		this.store = global.$store
+		this.settings = global.$settings
 
 		this.useProperTheme()
 		this.setMetadataUrl()
@@ -103,7 +103,7 @@ export default class Standalone
 		clearTimeout(this.pollTimeout)
 
 		this.requests.loadNext().then(() => {
-			if (! this.store.get('preserveLog')) {
+			if (! this.settings.global.preserveLog) {
 				this.requests.setItems(this.requests.all().slice(-1))
 			}
 


### PR DESCRIPTION
- refactored "local store" api to act only as a low-level persistent storage wrapper, all persistent application state is now managed via the settings api
- added support for `chrome.storage` extensions api (currently only used as a fall-back if `localStorage` is not available, eg. in Brave w/ default settings)
- settings modal now shows warning if no persistent storage is available
- what's new message is no longer shown if no persistent storage is available (this would lead to the message being every time clockwork is opened)

<img width="1192" alt="Screenshot 2020-04-19 at 19 35 49" src="https://user-images.githubusercontent.com/821582/79695100-041cc400-8275-11ea-81fe-059185e424a6.png">


