### PR TITLE
Added new "models" tab

### DIFF
--- a/src/components/RequestDetails.vue
+++ b/src/components/RequestDetails.vue
@@ -26,6 +26,7 @@
 
 			<div class="content-content">
 				<events-tab :active="activeTab == 'events'"></events-tab>
+				<models-tab :active="activeTab == 'models'"></models-tab>
 				<database-tab :active="activeTab == 'database'"></database-tab>
 				<cache-tab :active="activeTab == 'cache'"></cache-tab>
 				<redis-tab :active="activeTab == 'redis'"></redis-tab>
@@ -84,6 +85,7 @@ import DatabaseTab from './Tabs/DatabaseTab'
 import EmailsTab from './Tabs/EmailsTab'
 import EventsTab from './Tabs/EventsTab'
 import LogTab from './Tabs/LogTab'
+import ModelsTab from './Tabs/ModelsTab'
 import OutputTab from './Tabs/OutputTab'
 import PerformanceTab from './Tabs/PerformanceTab'
 import RedisTab from './Tabs/RedisTab'
@@ -95,8 +97,8 @@ import ViewsTab from './Tabs/ViewsTab'
 export default {
 	name: 'RequestDetails',
 	components: {
-		MessagesOverlay, SettingsModal, TabBar, CacheTab, DatabaseTab, EmailsTab, EventsTab, LogTab, OutputTab,
-		PerformanceTab, RedisTab, QueueTab, RoutesTab, UserTab, ViewsTab
+		MessagesOverlay, SettingsModal, TabBar, CacheTab, DatabaseTab, EmailsTab, EventsTab, LogTab, ModelsTab,
+		OutputTab, PerformanceTab, RedisTab, QueueTab, RoutesTab, UserTab, ViewsTab
 	},
 	computed: {
 		tabs() {
@@ -104,6 +106,7 @@ export default {
 				{ text: 'Performance', name: 'performance', icon: 'activity', shown: true },
 				{ text: 'Log', name: 'log', icon: 'edit-2', shown: this.shownTabs.log },
 				{ text: 'Events', name: 'events', icon: 'zap', shown: this.shownTabs.events },
+				{ text: 'Models', name: 'models', icon: 'disc', shown: this.shownTabs.models },
 				{ text: 'Database', name: 'database', icon: 'database', shown: this.shownTabs.database },
 				{ text: 'Cache', name: 'cache', icon: 'paperclip', shown: this.shownTabs.cache },
 				{ text: 'Redis', name: 'redis', icon: 'layers', shown: this.shownTabs.redis },
@@ -128,6 +131,8 @@ export default {
 		shownTabs() {
 			return {
 				log: this.$request?.log?.length > 0,
+				models: [ 'modelsRetrieved', 'modelsCreated', 'modelsUpdated', 'modelsDeleted' ].some(prop => this.$request?.[prop])
+					|| this.$request?.modelsActions.length > 0,
 				database: this.$request?.databaseQueriesCount > 0 || this.$request?.databaseQueries?.length > 0,
 				cache: [ 'cacheReads', 'cacheHits', 'cacheWrites', 'cacheDeletes', 'cacheTime' ].some(prop => this.$request?.[prop])
 					|| this.$request?.cacheQueries.length > 0,

--- a/src/components/Tabs/ModelsTab.vue
+++ b/src/components/Tabs/ModelsTab.vue
@@ -3,28 +3,32 @@
 		<div class="counters-row models-counters">
 			<div class="counter counter-retrieved" v-if="totals.retrieved">
 				<div class="counter-value">{{totals.retrieved}}</div>
-				<div class="counter-title">retrieved</div>
+				<div class="counter-title has-mark">retrieved</div>
 			</div>
 			<div class="counter counter-created" v-if="totals.created">
 				<div class="counter-value">{{totals.created}}</div>
-				<div class="counter-title">created</div>
+				<div class="counter-title has-mark">created</div>
 			</div>
 			<div class="counter counter-updated" v-if="totals.updated">
 				<div class="counter-value">{{totals.updated}}</div>
-				<div class="counter-title">updated</div>
+				<div class="counter-title has-mark">updated</div>
 			</div>
 			<div class="counter counter-deleted" v-if="totals.deleted">
 				<div class="counter-value">{{totals.deleted}}</div>
-				<div class="counter-title">deleted</div>
+				<div class="counter-title has-mark">deleted</div>
 			</div>
 		</div>
 
 		<div class="models-tabs" v-if="$request.modelsActions.length">
-			<a class="models-tab" :class="{ 'active': activeModelsTab == 'actions' }" href="#" @click.prevent="selectedModelsTab = 'actions'">Actions</a>
-			<a class="models-tab" :class="{ 'active': activeModelsTab == 'models' }" href="#" @click.prevent="selectedModelsTab = 'models'">Models</a>
+			<a class="models-tab" :class="{ 'active': activeModelsTab == 'actions' }" href="#" @click.prevent="selectedModelsTab = 'actions'">
+				<icon name="activity"></icon> Actions
+			</a>
+			<a class="models-tab" :class="{ 'active': activeModelsTab == 'models' }" href="#" @click.prevent="selectedModelsTab = 'models'">
+				<icon name="hash"></icon> Models
+			</a>
 		</div>
 
-		<details-table class="models-actions" :columns="[ 'Model', '', '' ]" :items="$request.modelsActions" :filter="actionsFilter" filter-example="App\User action:updated" v-if="activeModelsTab == 'actions'">
+		<details-table title="Actions" icon="activity" class="models-actions" :columns="[ 'Model', '', '' ]" :items="$request.modelsActions" :filter="actionsFilter" filter-example="App\User action:updated" v-if="activeModelsTab == 'actions'">
 			<template slot="body" slot-scope="{ items }">
 				<template v-for="action, index in items">
 					<tr class="actions-action" :key="`${$request.id}-models-actions-${index}`">
@@ -39,7 +43,7 @@
 						</td>
 						<td>
 							<a href="#" @click.prevent="action.isShowingDetails = ! action.isShowingDetails" title="Show details" v-if="action.attributes || action.changes">
-								<font-awesome-icon icon="search"></font-awesome-icon>
+								<icon :name="action.isShowingDetails ? 'chevron-up' : 'chevron-down'"></icon>
 							</a>
 						</td>
 					</tr>
@@ -60,7 +64,7 @@
 			</template>
 		</details-table>
 
-		<details-table class="models-counts" :columns="[ 'Model', 'Retrieved', 'Created', 'Updated', 'Deleted' ]" :items="modelsCounts" :filter="countsFilter" filter-example="App\User retrieved:>10" v-if="activeModelsTab == 'models'">
+		<details-table title="Models" icon="hash" class="models-counts" :columns="[ 'Model', 'Retrieved', 'Created', 'Updated', 'Deleted' ]" :items="modelsCounts" :filter="countsFilter" filter-example="App\User retrieved:>10" v-if="activeModelsTab == 'models'">
 			<template slot="body" slot-scope="{ items }">
 				<template v-for="counts, index in items">
 					<tr :key="`${$request.id}-models-counts-${index}`">
@@ -168,35 +172,35 @@ export default {
 @import '../../mixins.scss';
 
 .models-counters {
-	.counter-retrieved {
-		border-left: 3px solid rgb(120, 177, 222) !important;
+	.counter-retrieved .has-mark:before {
+		background: rgb(120, 177, 222);
 
 		@include dark {
-			border-left: 3px solid rgb(100, 157, 202) !important;
+			background: rgb(100, 157, 202);
 		}
 	}
 
-	.counter-created {
-		border-left: 3px solid rgb(177, 202, 109) !important;
+	.counter-created .has-mark:before {
+		background: rgb(177, 202, 109);
 
 		@include dark {
-			border-left: 3px solid rgb(157, 182, 89) !important;
+			background: rgb(157, 182, 89);
 		}
 	}
 
-	.counter-updated {
-		border-left: 3px solid hsl(50, 57, 61) !important;
+	.counter-updated .has-mark:before {
+		background: hsl(50, 57, 61);
 
 		@include dark {
-			border-left: 3px solid hsl(27, 39, 53) !important;
+			background: hsl(27, 39, 53);
 		}
 	}
 
-	.counter-deleted {
-		border-left: 3px solid rgb(231, 150, 151) !important;
+	.counter-deleted .has-mark:before {
+		background: rgb(231, 150, 151);
 
 		@include dark {
-			border-left: 3px solid rgb(211, 130, 131) !important;
+			background: rgb(211, 130, 131);
 		}
 	}
 }
@@ -205,27 +209,43 @@ export default {
 	display: flex;
 	flex: 1;
 	justify-content: center;
-	padding: 8px 0 4px;
+	margin-bottom: 10px;
+	margin-top: 30px;
 
 	.models-tab {
+		align-items: center;
+	    border-radius: 12px;
 		color: rgb(64, 64, 64);
 		cursor: default;
+		display: flex;
 		font-size: 12px;
-		line-height: 31px;
-		padding: 0 31px;
+		line-height: 26px;
+		padding: 0 26px;
 		text-align: center;
 		text-decoration: none;
 
+		@include dark {
+			color: rgb(158, 158, 158);
+		}
+
+		&:hover {
+			color: #258cdb;
+
+			@include dark { color: #f27e02; }
+		}
+
 		&.active {
-			color: rgb(37, 140, 219);
+		    background: rgb(39, 134, 243);
+		    color: #f5f5f5;
 
 			@include dark {
-				color: hsl(31, 98%, 48%);
+				background: #de7402;
+				color: #fff;
 			}
 		}
 
-		@include dark {
-			color: rgb(158, 158, 158);
+		.ui-icon {
+		    margin-right: 5px;
 		}
 	}
 }
@@ -300,19 +320,20 @@ export default {
 		}
 
 		h4 {
+			color: #333;
+			font-size: 90%;
+			font-weight: 600;
 			margin: 0 0 5px;
 		}
 	}
 
 	tr {
-		background: initial !important;
+		background: hsl(240, 20, 99) !important;
+		@include dark { background: hsl(240, 2, 14) !important; }
 
 		&:nth-child(4n), &:nth-child(4n-1) {
-			background: rgb(245, 245, 245) !important;
-
-			@include dark {
-				background: rgb(27, 27, 27) !important;
-			}
+			background: hsl(240, 20, 97) !important;
+			@include dark { background: hsl(240, 2, 13) !important; }
 		}
 	}
 }
@@ -330,7 +351,7 @@ export default {
 		background: hsla(206, 47%, 86%, 1);
 		border-radius: 8px;
 		color: hsla(205, 29%, 30%, 1);
-		font-size: 10px;
+		font-size: 11px;
 		padding: 3px 8px;
 		text-transform: uppercase;
 

--- a/src/components/Tabs/ModelsTab.vue
+++ b/src/components/Tabs/ModelsTab.vue
@@ -50,13 +50,31 @@
 
 					<tr class="actions-details" v-show="action.isShowingDetails" :key="`${$request.id}-models-actions-details-${index}`">
 						<td colspan="3">
-							<div v-if="action.attributes">
-								<h4>Attributes</h4>
-								<pretty-print :data="action.attributes"></pretty-print>
+							<div class="details-row" v-if="action.attributes">
+								<div class="row-group">
+									<h4>Attributes</h4>
+									<pretty-print :data="action.attributes"></pretty-print>
+								</div>
 							</div>
-							<div v-if="action.changes">
-								<h4>Changes</h4>
-								<pretty-print :data="action.changes"></pretty-print>
+							<div class="details-row" v-if="action.changes">
+								<div class="row-group">
+									<h4>Changes</h4>
+									<pretty-print :data="action.changes"></pretty-print>
+								</div>
+							</div>
+							<div class="details-row" v-if="action.query">
+								<div class="row-group group-query" v-if="action.query">
+									<h4>Query</h4>
+									<span>{{action.query}}</span>
+								</div>
+								<div class="row-group" v-if="action.duration">
+									<h4>Duration</h4>
+									<span>{{action.duration | round(3)}} ms</span>
+								</div>
+								<div class="row-group" v-if="action.connection">
+									<h4>Connection</h4>
+									<span>{{action.connection}}</span>
+								</div>
 							</div>
 						</td>
 					</tr>
@@ -324,6 +342,21 @@ export default {
 			font-size: 90%;
 			font-weight: 600;
 			margin: 0 0 5px;
+		}
+
+		.details-row {
+			display: flex;
+			margin-bottom: 5px;
+
+			.row-group {
+				margin-right: 15px;
+
+				&:last-child { margin-right: 0; }
+
+				&.group-query {
+					flex: 1;
+				}
+			}
 		}
 	}
 

--- a/src/components/Tabs/ModelsTab.vue
+++ b/src/components/Tabs/ModelsTab.vue
@@ -1,0 +1,373 @@
+<template>
+	<div v-show="active">
+		<div class="counters-row models-counters">
+			<div class="counter counter-retrieved" v-if="totals.retrieved">
+				<div class="counter-value">{{totals.retrieved}}</div>
+				<div class="counter-title">retrieved</div>
+			</div>
+			<div class="counter counter-created" v-if="totals.created">
+				<div class="counter-value">{{totals.created}}</div>
+				<div class="counter-title">created</div>
+			</div>
+			<div class="counter counter-updated" v-if="totals.updated">
+				<div class="counter-value">{{totals.updated}}</div>
+				<div class="counter-title">updated</div>
+			</div>
+			<div class="counter counter-deleted" v-if="totals.deleted">
+				<div class="counter-value">{{totals.deleted}}</div>
+				<div class="counter-title">deleted</div>
+			</div>
+		</div>
+
+		<div class="models-tabs" v-if="$request.modelsActions.length">
+			<a class="models-tab" :class="{ 'active': activeModelsTab == 'actions' }" href="#" @click.prevent="selectedModelsTab = 'actions'">Actions</a>
+			<a class="models-tab" :class="{ 'active': activeModelsTab == 'models' }" href="#" @click.prevent="selectedModelsTab = 'models'">Models</a>
+		</div>
+
+		<details-table class="models-actions" :columns="[ 'Model', '', '' ]" :items="$request.modelsActions" :filter="actionsFilter" filter-example="App\User action:updated" v-if="activeModelsTab == 'actions'">
+			<template slot="body" slot-scope="{ items }">
+				<template v-for="action, index in items">
+					<tr class="actions-action" :key="`${$request.id}-models-actions-${index}`">
+						<td class="action-model">
+							<shortened-text :full="action.model">{{action.shortModel}}</shortened-text>
+							<span class="action-key" v-if="action.key">
+								<span class="key-hash">#</span>{{action.key}}
+							</span>
+						</td>
+						<td class="database-duration">
+							<span class="action-action" :class="`action-${action.action}`">{{action.action}}</span>
+						</td>
+						<td>
+							<a href="#" @click.prevent="action.isShowingDetails = ! action.isShowingDetails" title="Show details" v-if="action.attributes || action.changes">
+								<font-awesome-icon icon="search"></font-awesome-icon>
+							</a>
+						</td>
+					</tr>
+
+					<tr class="actions-details" v-show="action.isShowingDetails" :key="`${$request.id}-models-actions-details-${index}`">
+						<td colspan="3">
+							<div v-if="action.attributes">
+								<h4>Attributes</h4>
+								<pretty-print :data="action.attributes"></pretty-print>
+							</div>
+							<div v-if="action.changes">
+								<h4>Changes</h4>
+								<pretty-print :data="action.changes"></pretty-print>
+							</div>
+						</td>
+					</tr>
+				</template>
+			</template>
+		</details-table>
+
+		<details-table class="models-counts" :columns="[ 'Model', 'Retrieved', 'Created', 'Updated', 'Deleted' ]" :items="modelsCounts" :filter="countsFilter" filter-example="App\User retrieved:>10" v-if="activeModelsTab == 'models'">
+			<template slot="body" slot-scope="{ items }">
+				<template v-for="counts, index in items">
+					<tr :key="`${$request.id}-models-counts-${index}`">
+						<td class="counts-model">
+							<shortened-text :full="counts.model">{{counts.shortModel}}</shortened-text>
+						</td>
+						<td class="counts-count">
+							<span class="count-text count-retrieved" v-if="counts.retrieved">{{counts.retrieved}}</span>
+							<span v-else>-</span>
+						</td>
+						<td class="counts-count">
+							<span class="count-text count-created" v-if="counts.created">{{counts.created}}</span>
+							<span v-else>-</span>
+						</td>
+						<td class="counts-count">
+							<span class="count-text count-updated" v-if="counts.updated">{{counts.updated}}</span>
+							<span v-else>-</span>
+						</td>
+						<td class="counts-count">
+							<span class="count-text count-deleted" v-if="counts.deleted">{{counts.deleted}}</span>
+							<span v-else>-</span>
+						</td>
+					</tr>
+				</template>
+			</template>
+		</details-table>
+	</div>
+</template>
+
+<script>
+import DetailsTable from '../UI/DetailsTable'
+import PrettyPrint from '../UI/PrettyPrint'
+import ShortenedText from '../UI/ShortenedText'
+import StackTrace from '../UI/StackTrace'
+
+import Filter from '../../features/filter'
+
+export default {
+	name: 'ModelsTab',
+	components: { DetailsTable, PrettyPrint, ShortenedText, StackTrace },
+	props: [ 'active' ],
+	data: () => ({
+		selectedModelsTab: 'actions',
+
+		actionsFilter: new Filter([
+			{ tag: 'model' },
+			{ tag: 'action' },
+			{ tag: 'file', map: item => item.shortPath }
+		]),
+
+		countsFilter: new Filter([
+			{ tag: 'model' },
+			{ tag: 'retrieved', type: 'number' },
+			{ tag: 'created', type: 'number' },
+			{ tag: 'updated', type: 'number' },
+			{ tag: 'deleted', type: 'number' }
+		])
+	}),
+	computed: {
+		totals() {
+			return {
+				retrieved: Object.values(this.$request.modelsRetrieved).reduce((sum, count) => sum + count, 0),
+				created: Object.values(this.$request.modelsCreated).reduce((sum, count) => sum + count, 0),
+				updated: Object.values(this.$request.modelsUpdated).reduce((sum, count) => sum + count, 0),
+				deleted: Object.values(this.$request.modelsDeleted).reduce((sum, count) => sum + count, 0)
+			}
+		},
+
+		activeModelsTab() {
+			return this.selectedModelsTab == 'actions' && ! this.$request.modelsActions.length
+				? 'models' : this.selectedModelsTab
+		},
+
+		modelsCounts() {
+			let models = new Set([
+				...Object.keys(this.$request.modelsRetrieved),
+				...Object.keys(this.$request.modelsCreated),
+				...Object.keys(this.$request.modelsUpdated),
+				...Object.keys(this.$request.modelsDeleted)
+			])
+
+			return Array.from(models).map(model => ({
+				model,
+				shortModel: model.split('\\').pop(),
+				retrieved: this.$request.modelsRetrieved[model],
+				created: this.$request.modelsCreated[model],
+				updated: this.$request.modelsUpdated[model],
+				deleted: this.$request.modelsDeleted[model]
+			}))
+		}
+	},
+	methods: {
+		isTabActive(tab) {
+			if (tab == '')
+
+			return this.selectedModelsTab == tab
+		},
+
+		showTab(tab) { this.selectedModelsTab = tab }
+	}
+}
+</script>
+
+<style lang="scss">
+@import '../../mixins.scss';
+
+.models-counters {
+	.counter-retrieved {
+		border-left: 3px solid rgb(120, 177, 222) !important;
+
+		@include dark {
+			border-left: 3px solid rgb(100, 157, 202) !important;
+		}
+	}
+
+	.counter-created {
+		border-left: 3px solid rgb(177, 202, 109) !important;
+
+		@include dark {
+			border-left: 3px solid rgb(157, 182, 89) !important;
+		}
+	}
+
+	.counter-updated {
+		border-left: 3px solid hsl(50, 57, 61) !important;
+
+		@include dark {
+			border-left: 3px solid hsl(27, 39, 53) !important;
+		}
+	}
+
+	.counter-deleted {
+		border-left: 3px solid rgb(231, 150, 151) !important;
+
+		@include dark {
+			border-left: 3px solid rgb(211, 130, 131) !important;
+		}
+	}
+}
+
+.models-tabs {
+	display: flex;
+	flex: 1;
+	justify-content: center;
+	padding: 8px 0 4px;
+
+	.models-tab {
+		color: rgb(64, 64, 64);
+		cursor: default;
+		font-size: 12px;
+		line-height: 31px;
+		padding: 0 31px;
+		text-align: center;
+		text-decoration: none;
+
+		&.active {
+			color: rgb(37, 140, 219);
+
+			@include dark {
+				color: hsl(31, 98%, 48%);
+			}
+		}
+
+		@include dark {
+			color: rgb(158, 158, 158);
+		}
+	}
+}
+
+.models-actions {
+	.actions-action {
+		.action-model {
+			width: 100%;
+		}
+
+		.action-key {
+			color: rgb(128, 128, 128);
+			font-size: 11px;
+
+			@include dark {
+				color: rgb(118, 118, 118);
+			}
+
+			.key-hash {
+				margin: 0 1px 0 2px;
+			}
+		}
+
+		.action-action {
+			background: hsla(206, 47%, 86%, 1);
+			border-radius: 8px;
+			color: hsla(205, 29%, 30%, 1);
+			font-size: 10px;
+			padding: 3px 8px;
+			text-transform: uppercase;
+
+			@include dark {
+				background: hsla(206, 100%, 16%, 1);
+				color: hsla(205, 90%, 70%, 1);
+			}
+
+			&.action-created {
+				background: hsl(76, 47%, 86%);
+				color: #586336;
+
+				@include dark {
+					background: hsla(76, 100%, 11%, 1);
+					color: hsla(75, 90%, 80%, 1);
+				}
+			}
+
+			&.action-updated {
+				background: #fffae2;
+				color: #a85919;
+
+				@include dark {
+					background: #382f00;
+					color: #fad89f;
+				}
+			}
+
+			&.action-deleted {
+				background: #ffebeb;
+				color: #c51f24;
+
+				@include dark {
+					background: #380000;
+					color: #ed797a;
+				}
+			}
+		}
+	}
+
+	.actions-details {
+		td {
+			padding: 0 14px 10px;
+		}
+
+		h4 {
+			margin: 0 0 5px;
+		}
+	}
+
+	tr {
+		background: initial !important;
+
+		&:nth-child(4n), &:nth-child(4n-1) {
+			background: rgb(245, 245, 245) !important;
+
+			@include dark {
+				background: rgb(27, 27, 27) !important;
+			}
+		}
+	}
+}
+
+.models-counts {
+	.counts-model {
+		width: 100%;
+	}
+
+	.counts-count {
+		text-align: center;
+	}
+
+	.count-text {
+		background: hsla(206, 47%, 86%, 1);
+		border-radius: 8px;
+		color: hsla(205, 29%, 30%, 1);
+		font-size: 10px;
+		padding: 3px 8px;
+		text-transform: uppercase;
+
+		@include dark {
+			background: hsla(206, 100%, 16%, 1);
+			color: hsla(205, 90%, 70%, 1);
+		}
+
+		&.count-created {
+			background: hsl(76, 47%, 86%);
+			color: #586336;
+
+			@include dark {
+				background: hsla(76, 100%, 11%, 1);
+				color: hsla(75, 90%, 80%, 1);
+			}
+		}
+
+		&.count-updated {
+			background: #fffae2;
+			color: #a85919;
+
+			@include dark {
+				background: #382f00;
+				color: #fad89f;
+			}
+		}
+
+		&.count-deleted {
+			background: #ffebeb;
+			color: #c51f24;
+
+			@include dark {
+				background: #380000;
+				color: #ed797a;
+			}
+		}
+	}
+}
+</style>

--- a/src/components/Tabs/ModelsTab.vue
+++ b/src/components/Tabs/ModelsTab.vue
@@ -33,10 +33,16 @@
 				<template v-for="action, index in items">
 					<tr class="actions-action" :key="`${$request.id}-models-actions-${index}`">
 						<td class="action-model">
-							<shortened-text :full="action.model">{{action.shortModel}}</shortened-text>
-							<span class="action-key" v-if="action.key">
-								<span class="key-hash">#</span>{{action.key}}
-							</span>
+							<div class="model-content">
+								<div class="content-text">
+									<shortened-text :full="action.model">{{action.shortModel}}</shortened-text>
+									<span class="action-key" v-if="action.key">
+										<span class="key-hash">#</span>{{action.key}}
+									</span>
+								</div>
+
+								<stack-trace class="content-trace" :trace="action.trace" :file="action.file" :line="action.line"></stack-trace>
+							</div>
 						</td>
 						<td class="database-duration">
 							<span class="action-action" :class="`action-${action.action}`">{{action.action}}</span>
@@ -272,6 +278,16 @@ export default {
 	.actions-action {
 		.action-model {
 			width: 100%;
+
+			.model-content {
+				display: flex;
+				flex-wrap: wrap;
+				width: 100%;
+
+				.content-trace {
+					margin-left: auto;
+				}
+			}
 		}
 
 		.action-key {
@@ -342,6 +358,10 @@ export default {
 			font-size: 90%;
 			font-weight: 600;
 			margin: 0 0 5px;
+
+			@include dark {
+				color: #b2b2b2;
+			}
 		}
 
 		.details-row {

--- a/src/components/UI/DetailsTable.vue
+++ b/src/components/UI/DetailsTable.vue
@@ -294,11 +294,14 @@ export default {
 			color: #333;
 			font-size: 90%;
 			font-weight: 600;
-			padding: 8px 0;
+			padding: 8px 6px;
 			text-align: center;
 			white-space: nowrap;
 
 			@include dark { color: #b2b2b2; }
+
+			&:first-child { padding-left: 12px; }
+			&:last-child { padding-right: 12px; }
 		}
 
 		td {

--- a/src/components/UI/Icon.vue
+++ b/src/components/UI/Icon.vue
@@ -16,6 +16,7 @@ import ChevronUpIcon from 'feather-icons/dist/icons/chevron-up.svg'
 import ClockIcon from 'feather-icons/dist/icons/clock.svg'
 import CpuIcon from 'feather-icons/dist/icons/cpu.svg'
 import DatabaseIcon from 'feather-icons/dist/icons/database.svg'
+import DiscIcon from 'feather-icons/dist/icons/disc.svg'
 import Edit2Icon from 'feather-icons/dist/icons/edit-2.svg'
 import ImageIcon from 'feather-icons/dist/icons/image.svg'
 import InfoIcon from 'feather-icons/dist/icons/info.svg'
@@ -42,9 +43,9 @@ export default {
 	name: 'Icon',
 	components: {
 		ActivityIcon, AlertCircleIcon, AlertTriangleIcon, ArrowDownCircleIcon, ChevronDownIcon, ChevronLeftIcon,
-		ChevronRightIcon, ChevronUpIcon, ClockIcon, CpuIcon, DatabaseIcon, Edit2Icon, ImageIcon, InfoIcon, LayersIcon,
-		LinkIcon, LockIcon, MailIcon, MapIcon, MenuIcon, PaperclipIcon, PercentIcon, PieChartIcon, SearchIcon,
-		SettingsIcon, SlashIcon, StarIcon, TerminalIcon, UserIcon, XIcon, XCircleIcon, ZapIcon
+		ChevronRightIcon, ChevronUpIcon, ClockIcon, CpuIcon, DatabaseIcon, DiscIcon, Edit2Icon, ImageIcon, InfoIcon,
+		LayersIcon, LinkIcon, LockIcon, MailIcon, MapIcon, MenuIcon, PaperclipIcon, PercentIcon, PieChartIcon,
+		SearchIcon, SettingsIcon, SlashIcon, StarIcon, TerminalIcon, UserIcon, XIcon, XCircleIcon, ZapIcon
 	},
 	props: [ 'name' ],
 	computed: {

--- a/src/components/UI/Icon.vue
+++ b/src/components/UI/Icon.vue
@@ -18,6 +18,7 @@ import CpuIcon from 'feather-icons/dist/icons/cpu.svg'
 import DatabaseIcon from 'feather-icons/dist/icons/database.svg'
 import DiscIcon from 'feather-icons/dist/icons/disc.svg'
 import Edit2Icon from 'feather-icons/dist/icons/edit-2.svg'
+import HashIcon from 'feather-icons/dist/icons/hash.svg'
 import ImageIcon from 'feather-icons/dist/icons/image.svg'
 import InfoIcon from 'feather-icons/dist/icons/info.svg'
 import LayersIcon from 'feather-icons/dist/icons/layers.svg'
@@ -43,8 +44,8 @@ export default {
 	name: 'Icon',
 	components: {
 		ActivityIcon, AlertCircleIcon, AlertTriangleIcon, ArrowDownCircleIcon, ChevronDownIcon, ChevronLeftIcon,
-		ChevronRightIcon, ChevronUpIcon, ClockIcon, CpuIcon, DatabaseIcon, DiscIcon, Edit2Icon, ImageIcon, InfoIcon,
-		LayersIcon, LinkIcon, LockIcon, MailIcon, MapIcon, MenuIcon, PaperclipIcon, PercentIcon, PieChartIcon,
+		ChevronRightIcon, ChevronUpIcon, ClockIcon, CpuIcon, DatabaseIcon, DiscIcon, Edit2Icon, HashIcon, ImageIcon,
+		InfoIcon, LayersIcon, LinkIcon, LockIcon, MailIcon, MapIcon, MenuIcon, PaperclipIcon, PercentIcon, PieChartIcon,
 		SearchIcon, SettingsIcon, SlashIcon, StarIcon, TerminalIcon, UserIcon, XIcon, XCircleIcon, ZapIcon
 	},
 	props: [ 'name' ],

--- a/src/components/UI/Popover.vue
+++ b/src/components/UI/Popover.vue
@@ -125,13 +125,13 @@ export default {
 		}
 
 		&:after {
-			border-color: transparent transparent rgba(#333, 0.05) transparent;
+			border-color: transparent transparent rgba(#333, 0.06) transparent;
 			border-width: 0 12px 12px 12px;
 			left: calc(50% - 11px);
 			top: 5px;
 
 			@include dark {
-				border-color: transparent transparent rgba(#888, 0.05) transparent;
+				border-color: transparent transparent hsla(240, 5, 8, 0.5) transparent;
 			}
 		}
 	}

--- a/src/main.scss
+++ b/src/main.scss
@@ -477,7 +477,20 @@ a {
 	}
 
 	a {
+		color: #a6a6a6;
 		text-decoration: none;
+
+		&:hover {
+			color: #969696;
+		}
+
+		@include dark {
+			color: #595959;
+
+			&:hover {
+				color: #696969;
+			}
+		}
 	}
 
 	.stack-frame {


### PR DESCRIPTION
- added new "models" tab including
    - total counts of retrieved, created, updated and deleted models
    - individual model actions with support for showing attributes of retrieved models and changes of created and updated models
    - per-model counts of retrieved, created, updated and deleted instances
- https://github.com/itsgoingd/clockwork/pull/397

<img width="1272" alt="Screenshot 2020-05-18 at 00 46 05" src="https://user-images.githubusercontent.com/821582/82162360-27528780-98a4-11ea-85fe-03056eacedaa.png">

<img width="1272" alt="Screenshot 2020-05-18 at 00 54 56" src="https://user-images.githubusercontent.com/821582/82162364-3802fd80-98a4-11ea-90ec-b1ea3ddc9e80.png">

## todo

- consider adding an option to show models stats in performance tab
- should we show model actions on timeline?
