### PR TITLE
Client-side metrics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8112,6 +8112,11 @@
       "resolved": "https://registry.npmjs.org/just-omit/-/just-omit-1.1.0.tgz",
       "integrity": "sha512-MBDr0a1Yyzht8KK3RS2oUKtJSKRrm+6txDuEFJOXoALnX4h+FcQyWSKVNDlZiClOSIRf1PkzJ+QkKm0pjLS7Mw=="
     },
+    "just-pick": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/just-pick/-/just-pick-2.1.0.tgz",
+      "integrity": "sha512-C1PuyjBfPOqv8mHxva3tcEG/BuZfyTjeNpFbg7/R9c/+/YVqVQd/tECZ7l4QX4vhONSRiOlJ6NyTbBJLMRw0wg=="
+    },
     "just-unique": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/just-unique/-/just-unique-3.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "just-intersect": "^3.1.0",
     "just-map-values": "^1.1.0",
     "just-omit": "^1.1.0",
+    "just-pick": "^2.1.0",
     "just-unique": "^3.2.0",
     "lodash": "^4.17.19",
     "moment": "^2.27.0",

--- a/src/components/Tabs/Performance/PerformanceClientSide.vue
+++ b/src/components/Tabs/Performance/PerformanceClientSide.vue
@@ -1,0 +1,208 @@
+<template>
+	<div class="performance-client-side">
+		<div class="counters-row performance-metrics" v-if="metrics.filter(m => m.value).length">
+			<div class="counter performance-chart-legend" v-if="metric.value" v-for="metric in metrics.filter(m => ! m.dom)">
+				<div class="counter-value">{{metric.value}} ms</div>
+				<div class="counter-title" :class="metric.color ? `has-mark mark-${metric.color}` : ''">{{metric.name}}</div>
+			</div>
+			<div class="counters-group right-aligned">
+				<div class="counter performance-chart-legend" v-if="metric.value" v-for="metric in metrics.filter(m => m.dom)">
+					<div class="counter-value">{{metric.value}} ms</div>
+					<div class="counter-title" :class="metric.color ? `has-mark mark-${metric.color}` : ''">{{metric.name}}</div>
+				</div>
+			</div>
+		</div>
+
+		<performance-chart :metrics="metrics.filter(m => m.onChart)" v-if="metrics.filter(m => m.value && m.onChart).length"></performance-chart>
+
+		<details-table title="Vitals" icon="activity" :items="[]" class="performance-vitals" v-if="Object.values(vitals).filter(v => v.value).length">
+			<template slot="toolbar">
+				<div class="header-group">
+					<a href="#" title="Show info" class="header-item" :class="{'active':showVitalsInfo}" @click.prevent="showVitalsInfo = ! showVitalsInfo">
+						<icon name="help-circle"></icon>
+					</a>
+				</div>
+			</template>
+			<template slot="body">
+				<tr>
+					<td>
+						<div class="vitals-row">
+							<div class="vitals-metric">
+								<div class="metric-name">Time To First Byte</div>
+								<div class="metric-value" :class="`value-${vitals.ttfb.score}`" v-if="vitals.ttfb.available">
+									{{ vitals.ttfb.value|round }} ms
+								</div>
+								<div class="metric-value value-unavailable" v-else>—</div>
+								<div class="metric-info" v-show="showVitalsInfo">
+									Time at which your server sends a response.
+									<a href="https://web.dev/time-to-first-byte/" target="_blank">Learn more</a>
+								</div>
+							</div>
+							<div class="vitals-metric">
+								<div class="metric-name">First Input Delay</div>
+								<div class="metric-value" :class="`value-${vitals.fid.score}`" v-if="vitals.fid.available">
+									{{ vitals.fid.value|round }} ms
+								</div>
+								<div class="metric-value value-unavailable" v-else>—</div>
+								<div class="metric-info" v-show="showVitalsInfo">
+									Time from when a user first interacts with a page to the time when the browser is actually able to respond to that interaction.
+									<a href="https://web.dev/fid/" target="_blank">Learn more</a>
+								</div>
+							</div>
+						</div>
+					</td>
+				</tr>
+				<tr>
+					<td>
+						<div class="vitals-row">
+							<div class="vitals-metric">
+								<div class="metric-name">First Contentful Paint</div>
+								<div class="metric-value" :class="`value-${vitals.fcp.score}`" v-if="vitals.fcp.available">
+									{{ vitals.fcp.value|round }} ms
+								</div>
+								<div class="metric-value value-unavailable" v-else>—</div>
+								<div class="metric-info" v-show="showVitalsInfo">
+									First Contentful Paint marks the time at which the first text or image is painted.
+									<a href="https://web.dev/first-contentful-paint/" target="_blank">Learn more</a>
+								</div>
+							</div>
+							<div class="vitals-metric">
+								<div class="metric-name">Largest Contentful Paint</div>
+								<div class="metric-value" :class="`value-${vitals.lcp.score}`" v-if="vitals.lcp.available">
+									{{ vitals.lcp.value|round }} ms
+								</div>
+								<div class="metric-value value-unavailable" v-else>—</div>
+								<div class="metric-info" v-show="showVitalsInfo">
+									Largest Contentful Paint marks the time at which the largest text or image is painted.
+									<a href="https://web.dev/lighthouse-largest-contentful-paint/" target="_blank">Learn more</a>
+								</div>
+							</div>
+						</div>
+					</td>
+				</tr>
+				<tr>
+					<td>
+						<div class="vitals-row">
+							<div class="vitals-metric">
+								<div class="metric-name">Cumulative Layout Shift</div>
+								<div class="metric-value" :class="`value-${vitals.cls.score}`" v-if="vitals.cls.available">
+									{{ vitals.cls.value|round }} ms
+								</div>
+								<div class="metric-value value-unavailable" v-else>—</div>
+								<div class="metric-info" v-show="showVitalsInfo">
+									Cumulative Layout Shift measures the movement of visible elements within the viewport.
+									<a href="https://web.dev/cls/" target="_blank">Learn more</a>
+								</div>
+							</div>
+							<div class="vitals-metric">
+								<div class="metric-name">Speed Index</div>
+								<div class="metric-value" :class="`value-${vitals.si.score}`" v-if="vitals.si.available">
+									{{ vitals.si.value|round }} ms
+								</div>
+								<div class="metric-value value-unavailable" v-else>—</div>
+								<div class="metric-info" v-show="showVitalsInfo">
+									Speed Index shows how quickly the contents of a page are visibly populated.
+									<a href="https://web.dev/speed-index/" target="_blank">Learn more</a>
+								</div>
+							</div>
+						</div>
+					</td>
+				</tr>
+			</template>
+		</details-table>
+	</div>
+</template>
+
+<script>
+import DetailsTable from '../../UI/DetailsTable'
+import PerformanceChart from './PerformanceChart'
+
+export default {
+	name: 'PerformanceClientSide',
+	components: { DetailsTable, PerformanceChart },
+	props: [ 'metrics', 'vitals' ],
+	data: () => ({
+		showVitalsInfo: true
+	})
+}
+</script>
+
+<style lang="scss">
+@import '../../../mixins.scss';
+
+.performance-vitals {
+	tbody tr:first-child .vitals-row {
+		margin-top: 10px;
+	}
+
+	.vitals-row {
+		display: flex;
+		flex-wrap: wrap;
+		margin: 0 auto;
+		max-width: 600px;
+	}
+
+	.vitals-metric {
+		align-items: center;
+		display: flex;
+		font-weight: 500;
+		flex-wrap: wrap;
+		padding: 12px 24px;
+		width: 50%;
+
+		&:first-child {
+			border-right: 1px solid #f3f3f3;
+		}
+
+		.metric-value {
+			border-radius: 8px;
+			font-size: 95%;
+			margin-left: auto;
+			padding: 2px 6px;
+
+			&.value-fast {
+				background: #e3eccb;
+				color: #586336;
+
+				@include dark {
+					background: hsla(76, 100%, 11%, 1);
+				    color: hsla(75, 90%, 80%, 1);
+				}
+			}
+
+			&.value-moderate {
+				background: #fff6cc;
+				color: #a85919;
+
+				@include dark {
+				    background: #382f00;
+				    color: #fad89f;
+				}
+			}
+
+			&.value-slow {
+				background: #ffebeb;
+				color: #c51f24;
+
+				@include dark {
+					background: #380000;
+					color: #ed797a;
+				}
+			}
+		}
+
+		.metric-info {
+			color: gray;
+			font-weight: normal;
+			margin-top: 10px;
+			width: 100%;
+
+			a {
+				color: gray;
+				display: block;
+				margin-top: 5px;
+			}
+		}
+	}
+}
+</style>

--- a/src/components/Tabs/Performance/PerformanceClientSide.vue
+++ b/src/components/Tabs/Performance/PerformanceClientSide.vue
@@ -157,7 +157,11 @@ export default {
 		width: 50%;
 
 		&:first-child {
-			border-right: 1px solid #f3f3f3;
+			border-right: 1px solid hsl(240, 20, 92);
+
+			@include dark {
+				border-right: 1px solid rgb(52, 52, 54);
+			}
 		}
 
 		.metric-value {

--- a/src/components/Tabs/Performance/PerformanceClientSide.vue
+++ b/src/components/Tabs/Performance/PerformanceClientSide.vue
@@ -18,7 +18,7 @@
 		<details-table title="Vitals" icon="activity" :items="[]" class="performance-vitals" v-if="Object.values(vitals).filter(v => v.value).length">
 			<template slot="toolbar">
 				<div class="header-group">
-					<a href="#" title="Show info" class="header-item" :class="{'active':showVitalsInfo}" @click.prevent="showVitalsInfo = ! showVitalsInfo">
+					<a href="#" title="Show info" class="header-item" :class="{'active':showVitalsInfo}" @click.prevent="toggleVitalsInfo">
 						<icon name="help-circle"></icon>
 					</a>
 				</div>
@@ -121,9 +121,15 @@ export default {
 	name: 'PerformanceClientSide',
 	components: { DetailsTable, PerformanceChart },
 	props: [ 'metrics', 'vitals' ],
-	data: () => ({
-		showVitalsInfo: true
-	})
+	computed: {
+		showVitalsInfo() { return this.$settings.global.performanceVitalsInfoShown }
+	},
+	methods: {
+		toggleVitalsInfo() {
+			this.$settings.global.performanceVitalsInfoShown = ! this.$settings.global.performanceVitalsInfoShown
+			this.$settings.save()
+		}
+	}
 }
 </script>
 

--- a/src/components/Tabs/PerformanceTab.vue
+++ b/src/components/Tabs/PerformanceTab.vue
@@ -73,6 +73,7 @@ export default {
 			let activeTab = this.selectedPerformanceTab || 'issues'
 
 			if (activeTab == 'issues' && ! this.databaseSlowQueries.length && ! this.performanceIssues.length) return 'timeline'
+			if (activeTab == 'client-side' && ! this.isClientSideTabAvailable) return 'timeline'
 
 			return activeTab
 		},

--- a/src/components/Tabs/PerformanceTab.vue
+++ b/src/components/Tabs/PerformanceTab.vue
@@ -27,6 +27,9 @@
 				<a class="performance-tab" :class="{ 'active': isTabActive('timeline') }" href="#" @click.prevent="showTab('timeline')">
 					<icon name="pie-chart"></icon> Timeline
 				</a>
+				<a class="performance-tab" :class="{ 'active': isTabActive('client-side') }" href="#" @click.prevent="showTab('client-side')" v-if="isClientSideTabAvailable">
+					<icon name="smile"></icon> Client-side
+				</a>
 				<a class="performance-tab" :class="{ 'active': isTabActive('profiler') }" href="#" @click.prevent="showTab('profiler')">
 					<icon name="clock"></icon> Profiler
 				</a>
@@ -34,6 +37,7 @@
 
 			<performance-log :issues="performanceIssues" :slow-queries="databaseSlowQueries" v-show="isTabActive('issues')"></performance-log>
 			<timeline name="performance" :timeline="$request.timeline" :tags="timelineTags" v-show="isTabActive('timeline')"></timeline>
+			<performance-client-side :metrics="$request.clientMetrics" :vitals="$request.webVitals" v-show="isTabActive('client-side')"></performance-client-side>
 			<profiler v-show="isTabActive('profiler')"></profiler>
 		</div>
 	</div>
@@ -41,6 +45,7 @@
 
 <script>
 import PerformanceChart from './Performance/PerformanceChart'
+import PerformanceClientSide from './Performance/PerformanceClientSide'
 import PerformanceLog from './Performance/PerformanceLog'
 import Profiler from './Performance/Profiler'
 import Timeline from './Performance/Timeline'
@@ -49,7 +54,7 @@ import Filter from '../../features/filter'
 
 export default {
 	name: 'PerformanceTab',
-	components: { PerformanceChart, PerformanceLog, Profiler, Timeline },
+	components: { PerformanceChart, PerformanceClientSide, PerformanceLog, Profiler, Timeline },
 	props: [ 'active' ],
 	data: () => ({
 		selectedPerformanceTab: null,
@@ -74,6 +79,11 @@ export default {
 
 		databaseSlowQueries() {
 			return this.$request.databaseQueries.filter(query => query.tags.includes('slow'))
+		},
+
+		isClientSideTabAvailable() {
+			return this.$request.clientMetrics.filter(m => m.value).length
+				|| Object.values(this.$request.webVitals).filter(v => v.value).length
 		},
 
 		performanceIssues() {

--- a/src/components/Tabs/PerformanceTab.vue
+++ b/src/components/Tabs/PerformanceTab.vue
@@ -98,10 +98,19 @@ export default {
 			this.selectedPerformanceTab = tab
 
 			if (tab == 'profiler') this.$profiler.loadRequest(this.$request)
+		},
+
+		refreshRequest() {
+			if (! this.active || ! this.$request) return
+
+			this.$request.loadClientMetrics(this.$requests)
+
+			if (this.activePerformanceTab == 'profiler') this.$profiler.loadRequest(this.$request)
 		}
 	},
 	watch: {
-		$request() { if (this.activePerformanceTab == 'profiler') this.$profiler.loadRequest(this.$request) }
+		active() { this.refreshRequest() },
+		$request() { this.refreshRequest() }
 	}
 }
 </script>

--- a/src/components/Tabs/QueueTab.vue
+++ b/src/components/Tabs/QueueTab.vue
@@ -88,7 +88,7 @@ export default {
 			if (attempt == 12) return
 			if (job.loadRequestTimeout) return
 
-			let request = this.$requests.findId(job.id) || await this.$requests.loadId(job.id, false)
+			let request = this.$requests.findId(job.id) || await this.$requests.loadId(job.id, null, false)
 
 			if (! request) {
 				return job.loadRequestTimeout = setTimeout(() => {

--- a/src/components/UI/DetailsTable.vue
+++ b/src/components/UI/DetailsTable.vue
@@ -9,7 +9,7 @@
 
 			<slot name="toolbar" :filter="filter">
 				<div class="header-group">
-					<div class="header-search">
+					<div class="header-search" v-if="filter">
 						<input type="search" v-model="filter.input" placeholder="Search...">
 						<icon name="search"></icon>
 					</div>

--- a/src/components/UI/Icon.vue
+++ b/src/components/UI/Icon.vue
@@ -19,6 +19,7 @@ import DatabaseIcon from 'feather-icons/dist/icons/database.svg'
 import DiscIcon from 'feather-icons/dist/icons/disc.svg'
 import Edit2Icon from 'feather-icons/dist/icons/edit-2.svg'
 import HashIcon from 'feather-icons/dist/icons/hash.svg'
+import HelpCircleIcon from 'feather-icons/dist/icons/help-circle.svg'
 import ImageIcon from 'feather-icons/dist/icons/image.svg'
 import InfoIcon from 'feather-icons/dist/icons/info.svg'
 import LayersIcon from 'feather-icons/dist/icons/layers.svg'
@@ -33,6 +34,7 @@ import PieChartIcon from 'feather-icons/dist/icons/pie-chart.svg'
 import SearchIcon from 'feather-icons/dist/icons/search.svg'
 import SettingsIcon from 'feather-icons/dist/icons/settings.svg'
 import SlashIcon from 'feather-icons/dist/icons/slash.svg'
+import SmileIcon from 'feather-icons/dist/icons/smile.svg'
 import StarIcon from 'feather-icons/dist/icons/star.svg'
 import TerminalIcon from 'feather-icons/dist/icons/terminal.svg'
 import UserIcon from 'feather-icons/dist/icons/user.svg'
@@ -44,9 +46,10 @@ export default {
 	name: 'Icon',
 	components: {
 		ActivityIcon, AlertCircleIcon, AlertTriangleIcon, ArrowDownCircleIcon, ChevronDownIcon, ChevronLeftIcon,
-		ChevronRightIcon, ChevronUpIcon, ClockIcon, CpuIcon, DatabaseIcon, DiscIcon, Edit2Icon, HashIcon, ImageIcon,
-		InfoIcon, LayersIcon, LinkIcon, LockIcon, MailIcon, MapIcon, MenuIcon, PaperclipIcon, PercentIcon, PieChartIcon,
-		SearchIcon, SettingsIcon, SlashIcon, StarIcon, TerminalIcon, UserIcon, XIcon, XCircleIcon, ZapIcon
+		ChevronRightIcon, ChevronUpIcon, ClockIcon, CpuIcon, DatabaseIcon, DiscIcon, Edit2Icon, HashIcon,
+		HelpCircleIcon, ImageIcon, InfoIcon, LayersIcon, LinkIcon, LockIcon, MailIcon, MapIcon, MenuIcon, PaperclipIcon,
+		PercentIcon, PieChartIcon, SearchIcon, SettingsIcon, SlashIcon, SmileIcon, StarIcon, TerminalIcon, UserIcon,
+		XIcon, XCircleIcon, ZapIcon
 	},
 	props: [ 'name' ],
 	computed: {

--- a/src/features/request.js
+++ b/src/features/request.js
@@ -35,6 +35,8 @@ export default class Request
 		this.viewsData = this.processViews(this.viewsData)
 		this.userData = this.processUserData(this.userData)
 		this.timeline = this.processTimeline(this.timelineData)
+		this.clientMetrics = this.processClientMetrics(this.clientMetrics)
+		this.webVitals = this.processWebVitals(this.webVitals)
 
 		this.processCommand()
 		this.processQueueJob()
@@ -167,6 +169,18 @@ export default class Request
 
 			return query
 		})
+	}
+
+	processClientMetrics(data) {
+		return [
+			{ name: 'Redirect', value: data.redirect },
+			{ name: 'DNS', value: data.dns, color: 'purple', onChart: true },
+			{ name: 'Connection', value: data.connection, color: 'blue', onChart: true },
+			{ name: 'Waiting', value: data.waiting, color: 'red', onChart: true },
+			{ name: 'Receiving', value: data.downloading, color: 'green', onChart: true },
+			{ name: 'To interactive', value: data.domLoading, color: 'blue', onChart: true, dom: true },
+			{ name: 'To complete', value: data.domInteractive, color: 'purple', onChart: true, dom: true }
+		]
 	}
 
 	processDatabase() {
@@ -483,6 +497,30 @@ export default class Request
 				})
 			}
 		})
+	}
+
+	processWebVitals(data) {
+		let vitals = {
+			cls: { slow: 7300, moderate: 3800 },
+			fid: { slow: 300, moderate: 100 },
+			lcp: { slow: 4000, moderate: 2000 },
+			fcp: { slow: 4000, moderate: 2000 },
+			ttfb: { slow: 600, moderate: 600 },
+			si: { slow: 5800, moderate: 4300 }
+		}
+
+		Object.keys(vitals).forEach(key => {
+			let value = data[key]
+			let score = 'fast'
+			let available = value !== undefined
+
+			if (value > vitals[key].slow) score = 'slow'
+			else if (value > vitals[key].moderate) score = 'moderate'
+
+			data[key] = { value, score, available }
+		})
+
+		return data
 	}
 
 	processCommand() {

--- a/src/features/request.js
+++ b/src/features/request.js
@@ -172,14 +172,16 @@ export default class Request
 	}
 
 	processClientMetrics(data) {
+		data = this.enforceObject(data)
+
 		return [
 			{ name: 'Redirect', value: data.redirect },
 			{ name: 'DNS', value: data.dns, color: 'purple', onChart: true },
 			{ name: 'Connection', value: data.connection, color: 'blue', onChart: true },
 			{ name: 'Waiting', value: data.waiting, color: 'red', onChart: true },
-			{ name: 'Receiving', value: data.downloading, color: 'green', onChart: true },
-			{ name: 'To interactive', value: data.domLoading, color: 'blue', onChart: true, dom: true },
-			{ name: 'To complete', value: data.domInteractive, color: 'purple', onChart: true, dom: true }
+			{ name: 'Receiving', value: data.receiving, color: 'green', onChart: true },
+			{ name: 'To interactive', value: data.domInteractive, color: 'blue', onChart: true, dom: true },
+			{ name: 'To complete', value: data.domComplete, color: 'purple', onChart: true, dom: true }
 		]
 	}
 
@@ -500,6 +502,8 @@ export default class Request
 	}
 
 	processWebVitals(data) {
+		data = this.enforceObject(data)
+
 		let vitals = {
 			cls: { slow: 7300, moderate: 3800 },
 			fid: { slow: 300, moderate: 100 },
@@ -579,6 +583,10 @@ export default class Request
 
 	enforceArray(input) {
 		return input instanceof Array ? input : []
+	}
+
+	enforceObject(input) {
+		return input instanceof Object && Object.keys(input).filter(key => key != '__type__').length ? input : {}
 	}
 
 	optionalNonEmptyObject(input, defaultValue) {

--- a/src/features/request.js
+++ b/src/features/request.js
@@ -74,6 +74,9 @@ export default class Request
 	}
 
 	loadClientMetrics(requests) {
+		// return if this is not an http request
+		if (! this.isRequest()) return
+
 		// return if we already have client metrics loaded, checks both clientMetrics and webVitals as webVitals take
 		// longer to measure
 		if (this.clientMetrics.some(m => m.value) && Object.values(this.webVitals).some(v => v.value)) return
@@ -533,7 +536,7 @@ export default class Request
 		Object.keys(vitals).forEach(key => {
 			let value = data[key]
 			let score = 'fast'
-			let available = value !== undefined
+			let available = ! isNaN(parseFloat(value))
 
 			if (value > vitals[key].slow) score = 'slow'
 			else if (value > vitals[key].moderate) score = 'moderate'

--- a/src/features/settings.js
+++ b/src/features/settings.js
@@ -67,6 +67,7 @@ export default class Settings
 				hideQueueJobTypeRequests: this.platform instanceof Extension,
 				hideTestTypeRequests: this.platform instanceof Extension,
 				ignoredUpdateNotifications: {},
+				performanceVitalsInfoShown: true,
 				preserveLog: true,
 				requestsListCollapsed: false,
 				requestSidebarCollapsed: false,

--- a/src/main.scss
+++ b/src/main.scss
@@ -215,8 +215,7 @@ a {
 		.counter {
 			border-right: 1px solid hsl(240, 20, 92);
 			cursor: default;
-			flex: 0 1 120px;
-			padding: 12px 28px 13px;
+			padding: 12px 24px 13px;
 
 			@include dark {
 				border-right: 1px solid rgb(52, 52, 54);
@@ -224,7 +223,7 @@ a {
 
 			.counter-value {
 				color: #258cdb;
-				font-size: 175%;
+				font-size: 170%;
 				margin-bottom: 3px;
 				white-space: nowrap;
 

--- a/src/platform/extension.js
+++ b/src/platform/extension.js
@@ -100,11 +100,11 @@ export default class Extension
 			this.requests.setRemote(message.request.url, options)
 
 			let request = Request.placeholder(options.id, message.request)
-			this.requests.loadId(options.id, request)
+			this.requests.loadId(options.id, null, request)
 
 			options.subrequests.forEach(subrequest => {
 				this.requests.setRemote(subrequest.url, { path: subrequest.path })
-				this.requests.loadId(subrequest.id, Request.placeholder(subrequest.id, subrequest, request))
+				this.requests.loadId(subrequest.id, null, Request.placeholder(subrequest.id, subrequest, request))
 			})
 
 			this.requests.setRemote(message.request.url, options)
@@ -139,7 +139,7 @@ export default class Extension
 				this.updateNotification.serverVersion = options.version
 
 				this.requests.setRemote(request.url, options)
-				this.requests.loadId(options.id, Request.placeholder(options.id, request))
+				this.requests.loadId(options.id, null, Request.placeholder(options.id, request))
 
 				if (! this.settings.global.hideCommandTypeRequests || ! this.settings.global.hideQueueJobTypeRequests || ! this.settings.global.hideTestTypeRequests) {
 					this.startPollingRequests()


### PR DESCRIPTION
- added client-side metrics section to the performance tab
    - client metrics and a simple chart
    - web vitals with short description and link to the documentation
    - web vitals use red/yellow/green colors for good/needs improvement/poor values
- client-metrics are loaded with a delay in several attempts as they won't be available right away after request processing
- server-side https://github.com/itsgoingd/clockwork/pull/422

<img width="1377" alt="Screenshot 2020-09-13 at 15 29 49" src="https://user-images.githubusercontent.com/821582/93019264-27566000-f5d6-11ea-8da7-58f4f42200c9.png">
