### PR TITLE
Simple dynamic polling

### DIFF
--- a/platforms/chrome/background.js
+++ b/platforms/chrome/background.js
@@ -26,7 +26,7 @@ api.runtime.onMessage.addListener((message, sender, callback) => {
 				return callback({ error: 'requires-authentication', message: data.message, requires: data.requires })
 			}
 
-			if (! (data instanceof Object) || ! Object.keys(data).length) {
+			if (! (data instanceof Array) && (! (data instanceof Object) || ! Object.keys(data).length)) {
 				return callback({ error: 'empty-response', message: 'Server returned an empty metadata.' })
 			}
 

--- a/platforms/firefox/background.js
+++ b/platforms/firefox/background.js
@@ -26,7 +26,7 @@ api.runtime.onMessage.addListener((message, sender, callback) => {
 				return callback({ error: 'requires-authentication', message: data.message, requires: data.requires })
 			}
 
-			if (! (data instanceof Object) || ! Object.keys(data).length) {
+			if (! (data instanceof Array) && (! (data instanceof Object) || ! Object.keys(data).length)) {
 				return callback({ error: 'empty-response', message: 'Server returned an empty metadata.' })
 			}
 

--- a/src/platform/extension.js
+++ b/src/platform/extension.js
@@ -21,6 +21,7 @@ export default class Extension
 		this.setMetadataClient()
 
 		this.listenToRequests()
+		this.throttlePolling()
 
 		this.loadLastRequest()
 	}

--- a/src/platform/extension.js
+++ b/src/platform/extension.js
@@ -216,10 +216,10 @@ export default class Extension
 		].filter(Boolean)
 
 		this.requests.withQuery({ 'type[]': types }, () => {
-			this.requests.loadNext().then(() => {
-				if (this.isPolling) this.pollTimeout = setTimeout(() => this.pollRequests(), this.pollingInterval)
+			this.requests.loadNext().then(requests => {
+				if (this.isPolling) this.pollTimeout = setTimeout(() => this.pollRequests(), this.updatePollingInterval(requests.length))
 			}).catch(() => {
-				if (this.isPolling) this.pollTimeout = setTimeout(() => this.pollRequests(), this.pollingInterval)
+				if (this.isPolling) this.pollTimeout = setTimeout(() => this.pollRequests(), this.updatePollingInterval(false))
 			})
 		})
 	}
@@ -230,6 +230,22 @@ export default class Extension
 
 			if (! document.hidden && this.isPolling) this.pollRequests()
 		});
+	}
+
+	updatePollingInterval(requestsReceived) {
+		let currentTime = (new Date).getTime()
+
+		if (requestsReceived || ! this.pollingLastReceived) {
+			this.pollingLastReceived = currentTime
+		}
+
+		if (currentTime - this.pollingLastReceived > 60000) {
+			return this.pollingInterval = 5000
+		} else if (currentTime - this.pollingLastReceived > 30000) {
+			return this.pollingInterval = 2500
+		} else {
+			return this.pollingInterval = 1000
+		}
 	}
 
 	settingsChanged() {

--- a/src/platform/standalone.js
+++ b/src/platform/standalone.js
@@ -109,14 +109,14 @@ export default class Standalone
 	pollRequests() {
 		clearTimeout(this.pollTimeout)
 
-		this.requests.loadNext().then(() => {
+		this.requests.loadNext().then(requests => {
 			if (! this.settings.global.preserveLog) {
 				this.requests.setItems(this.requests.all().slice(-1))
 			}
 
-			this.pollTimeout = setTimeout(() => this.pollRequests(), this.pollingInterval)
+			this.pollTimeout = setTimeout(() => this.pollRequests(), this.updatePollingInterval(requests.length))
 		}).catch(() => {
-			this.pollTimeout = setTimeout(() => this.pollRequests(), this.pollingInterval)
+			this.pollTimeout = setTimeout(() => this.pollRequests(), this.updatePollingInterval(false))
 		})
 	}
 
@@ -126,6 +126,22 @@ export default class Standalone
 
 			if (! document.hidden) this.pollRequests()
 		});
+	}
+
+	updatePollingInterval(requestsReceived) {
+		let currentTime = (new Date).getTime()
+
+		if (requestsReceived || ! this.pollingLastReceived) {
+			this.pollingLastReceived = currentTime
+		}
+
+		if (currentTime - this.pollingLastReceived > 60000) {
+			return this.pollingInterval = 5000
+		} else if (currentTime - this.pollingLastReceived > 30000) {
+			return this.pollingInterval = 2500
+		} else {
+			return this.pollingInterval = 1000
+		}
 	}
 
 	settingsChanged() {

--- a/src/platform/standalone.js
+++ b/src/platform/standalone.js
@@ -53,7 +53,7 @@ export default class Standalone
 							throw { error: 'requires-authentication', message: data.message, requires: data.requires }
 						} else if (response.status != 200) {
 							throw { error: 'error-response', message: 'Server returned an error response.' }
-						} else if (! (data instanceof Object) || ! Object.keys(data).length) {
+						} else if (! (data instanceof Array) && (! (data instanceof Object) || ! Object.keys(data).length)) {
 							throw { error: 'empty-response', message: 'Server returned an empty metadata.' }
 						}
 


### PR DESCRIPTION
- added a simple dynamic polling interval implementation
    - default polling interval is 1s, if we don't receive any requests for 30 seconds it is cut in half (2.5s) and cut again after 60 seconds of no requests (5s)
    - after receiving non-empty api response it is reset to 1s again
- fixed polling in extension mode not being throttled when the tab is not visible
