### PR TITLE
Use v-if instead of v-show to minimize DOM interaction

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,8 +1,8 @@
 <template>
 	<div class="application split-view" :class="appearance">
-		<requests-list v-show="showRequestsList"></requests-list>
+		<requests-list v-if="showRequestsList"></requests-list>
 		<request-details></request-details>
-		<request-sidebar v-show="showRequestSidebar"></request-sidebar>
+		<request-sidebar v-if="showRequestSidebar"></request-sidebar>
 
 		<whats-new></whats-new>
 	</div>

--- a/src/components/Details/DetailsRequest.vue
+++ b/src/components/Details/DetailsRequest.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="content-request">
 		<div class="counters-row">
-			<div class="counter request-type" v-show="$request.isCommand() || $request.isQueueJob() || $request.isTest() || $request.isAjax()">
+			<div class="counter request-type" v-if="$request.isCommand() || $request.isQueueJob() || $request.isTest() || $request.isAjax()">
 				<template v-if="$request.isCommand()">
 					<span class="type-text">CMD</span>
 				</template>

--- a/src/components/Details/MessagesOverlay.vue
+++ b/src/components/Details/MessagesOverlay.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="messages-overlay">
-		<parent-request compact="true" v-show="$settings.global.requestSidebarCollapsed"></parent-request>
-		<exception-section compact="true" v-show="$settings.global.requestSidebarCollapsed"></exception-section>
+		<parent-request compact="true" v-if="$settings.global.requestSidebarCollapsed"></parent-request>
+		<exception-section compact="true" v-if="$settings.global.requestSidebarCollapsed"></exception-section>
 
 		<div class="update-notification" v-if="updateNotification">
 			<icon name="info"></icon>

--- a/src/components/Details/TabHandle.vue
+++ b/src/components/Details/TabHandle.vue
@@ -1,8 +1,8 @@
 <template>
 	<a @click="selectTab" class="details-header-tab" :class="{'active':active, 'short':short, 'full':full}" href="#">
 		<icon :name="icon" :title="text" v-if="icon"></icon>
-		<div class="tab-title" v-show="! short">{{text}}</div>
-		<div class="tab-badge" v-show="badge && ! short">{{badge}}</div>
+		<div class="tab-title" v-if="! short">{{text}}</div>
+		<div class="tab-badge" v-if="badge && ! short">{{badge}}</div>
 	</a>
 </template>
 

--- a/src/components/RequestDetails.vue
+++ b/src/components/RequestDetails.vue
@@ -1,9 +1,9 @@
 <template>
 	<div class="split-view-pane split-view-details popover-viewport">
 
-		<div class="details-header" v-show="$platform.hasFeature('tab-bar')">
+		<div class="details-header" v-if="$platform.hasFeature('tab-bar')">
 			<div class="icons">
-				<a href="#" title="Toggle requests" @click.prevent="toggleRequestsList" v-show="$platform.hasFeature('requests-list')">
+				<a href="#" title="Toggle requests" @click.prevent="toggleRequestsList" v-if="$platform.hasFeature('requests-list')">
 					<icon :name="$settings.global.requestsListCollapsed ? 'chevron-right' : 'chevron-left'"></icon>
 				</a>
 			</div>
@@ -44,26 +44,26 @@
 
 		</div>
 
-		<div class="details-loading-overlay" v-show="$get($request, 'loading') && ! $authentication.shown">
+		<div class="details-loading-overlay" v-if="$get($request, 'loading') && ! $authentication.shown">
 			<spinner name="fading-circle" :color="$settings.appearance == 'dark' ? '#f27e02' : '#258cdb'"></spinner>
 		</div>
 
-		<div class="details-error-overlay" v-show="$get($request, 'error') && $get($request, 'error.error') != 'requires-authentication'">
+		<div class="details-error-overlay" v-if="$get($request, 'error') && $get($request, 'error.error') != 'requires-authentication'">
 			<icon name="alert-circle"></icon>
 			<p class="title">Error loading request metadata.</p>
 			<p class="message">{{$get($request, 'error.message')}}</p>
 		</div>
 
-		<div class="details-authentication-overlay" :class="{failed:$authentication.failed}" v-show="$authentication.shown">
+		<div class="details-authentication-overlay" :class="{failed:$authentication.failed}" v-if="$authentication.shown">
 			<form @submit.prevent="$authentication.attempt()">
 				<icon name="lock"></icon>
 				<p class="title">This site requires authentication.</p>
 				<p class="title failed">Authentication failed.</p>
-				<p class="message" v-show="$authentication.message">{{ $authentication.message }}</p>
-				<p v-show="$authentication.requires.includes('username')">
+				<p class="message" v-if="$authentication.message">{{ $authentication.message }}</p>
+				<p v-if="$authentication.requires.includes('username')">
 					<input type="text" v-model="$authentication.username" placeholder="Username">
 				</p>
-				<p v-show="$authentication.requires.includes('password')">
+				<p v-if="$authentication.requires.includes('password')">
 					<input type="password" v-model="$authentication.password" placeholder="Password">
 				</p>
 				<p>

--- a/src/components/RequestSidebar.vue
+++ b/src/components/RequestSidebar.vue
@@ -70,12 +70,12 @@
 			<request-tab v-else-if="$request"></request-tab>
 
 			<div class="content-actions">
-				<a href="#" class="button" @click.prevent="$sharing.toggle()" v-show="$platform.hasFeature('sharing')">
+				<a href="#" class="button" @click.prevent="$sharing.toggle()" v-if="$platform.hasFeature('sharing')">
 					<icon name="share"></icon>
 					Share
 				</a>
 
-				<a href="#" class="button" @click.prevent="$sharing.toggleDelete()" v-show="$platform.hasFeature('delete-shared')">
+				<a href="#" class="button" @click.prevent="$sharing.toggleDelete()" v-if="$platform.hasFeature('delete-shared')">
 					<icon name="trash-2"></icon>
 					Delete
 				</a>

--- a/src/components/Settings/SettingsModal.vue
+++ b/src/components/Settings/SettingsModal.vue
@@ -48,10 +48,10 @@
 						<option value="vs-code">Visual Studio Code</option>
 					</select>
 
-					<div class="help-text" v-show="$settings.global.editor == 'atom'">
+					<div class="help-text" v-if="$settings.global.editor == 'atom'">
 						Requires <a href="https://atom.io/packages/open" target="_blank">Atom Open</a> package.
 					</div>
-					<div class="help-text" v-show="$settings.global.editor == 'sublime'">
+					<div class="help-text" v-if="$settings.global.editor == 'sublime'">
 						Requires <a href="https://github.com/inopinatus/sublime_url" target="_blank">sublime_url</a> on MacOS. Not supported on other platforms.
 					</div>
 				</div>
@@ -72,7 +72,7 @@
 				</div>
 			</div>
 
-			<div class="controls-group" v-show="$platform.hasFeature('requests-list')">
+			<div class="controls-group" v-if="$platform.hasFeature('requests-list')">
 				<label for="settings-on-demand-secret">On-demand</label>
 
 				<div class="controls">
@@ -84,7 +84,7 @@
 				</div>
 			</div>
 
-			<div class="controls-group" v-show="$platform.hasFeature('requests-list')">
+			<div class="controls-group" v-if="$platform.hasFeature('requests-list')">
 				<label></label>
 
 				<div class="controls">
@@ -99,7 +99,7 @@
 				</div>
 			</div>
 
-			<div class="controls-group" v-show="$platform.hasFeature('requests-list')">
+			<div class="controls-group" v-if="$platform.hasFeature('requests-list')">
 				<label></label>
 
 				<div class="controls">

--- a/src/components/Tabs/CacheTab.vue
+++ b/src/components/Tabs/CacheTab.vue
@@ -1,31 +1,31 @@
 <template>
-	<div v-show="active">
+	<div v-if="active">
 		<div class="counters-row">
-			<div class="counter" v-show="$request.cacheQueries.length">
+			<div class="counter" v-if="$request.cacheQueries.length">
 				<div class="counter-value">{{$request.cacheQueries.length}}</div>
 				<div class="counter-title">queries</div>
 			</div>
-			<div class="counter" v-show="$request.cacheReads !== null">
+			<div class="counter" v-if="$request.cacheReads !== null">
 				<div class="counter-value">{{$request.cacheReads}}</div>
 				<div class="counter-title">reads</div>
 			</div>
-			<div class="counter" v-show="$request.cacheHits !== null">
+			<div class="counter" v-if="$request.cacheHits !== null">
 				<div class="counter-value">{{$request.cacheHits}}</div>
 				<div class="counter-title">hits</div>
 			</div>
-			<div class="counter" v-show="$request.cacheMisses !== null">
+			<div class="counter" v-if="$request.cacheMisses !== null">
 				<div class="counter-value">{{$request.cacheMisses}}</div>
 				<div class="counter-title">misses</div>
 			</div>
-			<div class="counter" v-show="$request.cacheWrites !== null">
+			<div class="counter" v-if="$request.cacheWrites !== null">
 				<div class="counter-value">{{$request.cacheWrites}}</div>
 				<div class="counter-title">writes</div>
 			</div>
-			<div class="counter" v-show="$request.cacheDeletes !== null">
+			<div class="counter" v-if="$request.cacheDeletes !== null">
 				<div class="counter-value">{{$request.cacheDeletes}}</div>
 				<div class="counter-title">deletes</div>
 			</div>
-			<div class="counter" v-show="$request.cacheTime !== null">
+			<div class="counter" v-if="$request.cacheTime !== null">
 				<div class="counter-value">{{$request.cacheTime}}</div>
 				<div class="counter-title">time</div>
 			</div>

--- a/src/components/Tabs/CommandTab.vue
+++ b/src/components/Tabs/CommandTab.vue
@@ -1,9 +1,9 @@
 <template>
 	<div class="command-tab">
-		<sidebar-section title="Arguments" name="arguments" :items="$request.commandArgumentsMerged" filter-example="&quot;Mike Jones&quot; name:name" v-show="$request.commandArgumentsMerged.length">
+		<sidebar-section title="Arguments" name="arguments" :items="$request.commandArgumentsMerged" filter-example="&quot;Mike Jones&quot; name:name" v-if="$request.commandArgumentsMerged.length">
 		</sidebar-section>
 
-		<sidebar-section title="Options" name="options" :items="$request.commandOptionsMerged" filter-example="&quot;Mike Jones&quot; name:name" v-show="$request.commandOptionsMerged.length">
+		<sidebar-section title="Options" name="options" :items="$request.commandOptionsMerged" filter-example="&quot;Mike Jones&quot; name:name" v-if="$request.commandOptionsMerged.length">
 		</sidebar-section>
 	</div>
 </template>

--- a/src/components/Tabs/DatabaseTab.vue
+++ b/src/components/Tabs/DatabaseTab.vue
@@ -1,5 +1,5 @@
 <template>
-	<div v-show="active">
+	<div v-if="active">
 		<div class="counters-row">
 			<div class="counter">
 				<div class="counter-value">{{$request.databaseQueriesCount}}</div>
@@ -65,7 +65,7 @@
 									<pretty-print :data="query.bindings"></pretty-print>
 								</div>
 							</div>
-							<stack-trace class="database-query-path" :trace="query.trace" :file="query.file" :line="query.line"></stack-trace>
+							<stack-trace v-if="query.trace || query.file" class="database-query-path" :trace="query.trace" :file="query.file" :line="query.line"></stack-trace>
 						</div>
 					</td>
 					<td class="database-duration">

--- a/src/components/Tabs/EventsTab.vue
+++ b/src/components/Tabs/EventsTab.vue
@@ -1,5 +1,5 @@
 <template>
-	<div v-show="active">
+	<div v-if="active">
 		<details-table title="Events" icon="zap" :columns="['Time', 'Event', '']" :items="$request.events" :filter="filter" filter-example="&quot;user registered&quot; file:Controller.php time:&lt;13:08:30">
 			<template slot="body" slot-scope="{ items }">
 				<tr v-for="event, index in items" :key="`${$request.id}-${index}`">
@@ -16,7 +16,7 @@
 							</div>
 							<stack-trace class="fired-query-path" :trace="event.trace" :file="event.file" :line="event.line"></stack-trace>
 						</div>
-						<div class="fired-event-details" v-show="isEventExpanded(event)">
+						<div class="fired-event-details" v-if="isEventExpanded(event)">
 							<div class="fired-event-parameters" v-if="! event.objectEvent">
 								<h4>Parameters</h4>
 								<pretty-print :data="event.data"></pretty-print>

--- a/src/components/Tabs/LogTab.vue
+++ b/src/components/Tabs/LogTab.vue
@@ -1,5 +1,5 @@
 <template>
-	<div v-show="active">
+	<div v-if="active">
 		<details-table title="Messages" icon="edit-2" :columns="['Time', 'Level', 'Message']" :items="log" :filter="filter" filter-example="query failed level:error file:Controller.php time:>13:08:29">
 			<template slot="body" slot-scope="{ items }">
 				<tr v-for="message, index in items" :class="{ 'log-row': true, 'error': ['emergency', 'alert', 'critical', 'error'].includes(message.level), warning: message.level == 'warning' }" :key="`${$request.id}-${index}`">
@@ -9,7 +9,7 @@
 						<div class="log-message">
 							<div class="log-message-content">
 								<pretty-print :data="message.message" :linkify="true"></pretty-print>
-								<div class="log-message-context" v-show="message.context">
+								<div class="log-message-context" v-if="message.context">
 									<pretty-print :data="message.context"></pretty-print>
 								</div>
 							</div>

--- a/src/components/Tabs/ModelsTab.vue
+++ b/src/components/Tabs/ModelsTab.vue
@@ -1,5 +1,5 @@
 <template>
-	<div v-show="active">
+	<div v-if="active">
 		<div class="counters-row models-counters">
 			<div class="counter counter-retrieved" v-if="totals.retrieved">
 				<div class="counter-value">{{totals.retrieved}}</div>
@@ -54,7 +54,7 @@
 						</td>
 					</tr>
 
-					<tr class="actions-details" v-show="action.isShowingDetails" :key="`${$request.id}-models-actions-details-${index}`">
+					<tr class="actions-details" v-if="action.isShowingDetails" :key="`${$request.id}-models-actions-details-${index}`">
 						<td colspan="3">
 							<div class="details-row" v-if="action.attributes">
 								<div class="row-group">

--- a/src/components/Tabs/NotificationsTab.vue
+++ b/src/components/Tabs/NotificationsTab.vue
@@ -1,5 +1,5 @@
 <template>
-	<div v-show="active">
+	<div v-if="active">
 		<details-table title="Notifications" icon="mail" :columns="columns" :items="$request.notifications" :filter="filter" filter-example="&quot;User Registration&quot; to:its@underground.works" class="notifications-notifications">
 			<template slot="body" slot-scope="{ items }">
 				<template v-for="notification, index in items">
@@ -26,7 +26,7 @@
 						</td>
 					</tr>
 
-					<tr class="notifications-details" v-show="notification.isShowingDetails" :key="`${$request.id}-notifications-details-${index}`">
+					<tr class="notifications-details" v-if="notification.isShowingDetails" :key="`${$request.id}-notifications-details-${index}`">
 						<td :colspan="columns.length">
 							<div class="details-row">
 								<div class="row-group" v-if="notification.to">

--- a/src/components/Tabs/OutputTab.vue
+++ b/src/components/Tabs/OutputTab.vue
@@ -1,5 +1,5 @@
 <template>
-	<div v-show="active">
+	<div v-if="active">
 		<div class="command-output" v-html="formattedOutput"></div>
 	</div>
 </template>

--- a/src/components/Tabs/Performance/PerformanceClientSide.vue
+++ b/src/components/Tabs/Performance/PerformanceClientSide.vue
@@ -33,7 +33,7 @@
 									{{ vitals.ttfb.value|round }} ms
 								</div>
 								<div class="metric-value value-unavailable" v-else>—</div>
-								<div class="metric-info" v-show="showVitalsInfo">
+								<div class="metric-info" v-if="showVitalsInfo">
 									Time at which your server sends a response.
 									<a href="https://web.dev/time-to-first-byte/" target="_blank">Learn more</a>
 								</div>
@@ -44,7 +44,7 @@
 									{{ vitals.fid.value|round }} ms
 								</div>
 								<div class="metric-value value-unavailable" v-else>—</div>
-								<div class="metric-info" v-show="showVitalsInfo">
+								<div class="metric-info" v-if="showVitalsInfo">
 									Time from when a user first interacts with a page to the time when the browser is actually able to respond to that interaction.
 									<a href="https://web.dev/fid/" target="_blank">Learn more</a>
 								</div>
@@ -61,7 +61,7 @@
 									{{ vitals.fcp.value|round }} ms
 								</div>
 								<div class="metric-value value-unavailable" v-else>—</div>
-								<div class="metric-info" v-show="showVitalsInfo">
+								<div class="metric-info" v-if="showVitalsInfo">
 									First Contentful Paint marks the time at which the first text or image is painted.
 									<a href="https://web.dev/first-contentful-paint/" target="_blank">Learn more</a>
 								</div>
@@ -72,7 +72,7 @@
 									{{ vitals.lcp.value|round }} ms
 								</div>
 								<div class="metric-value value-unavailable" v-else>—</div>
-								<div class="metric-info" v-show="showVitalsInfo">
+								<div class="metric-info" v-if="showVitalsInfo">
 									Largest Contentful Paint marks the time at which the largest text or image is painted.
 									<a href="https://web.dev/lighthouse-largest-contentful-paint/" target="_blank">Learn more</a>
 								</div>
@@ -89,7 +89,7 @@
 									{{ vitals.cls.value|round }} ms
 								</div>
 								<div class="metric-value value-unavailable" v-else>—</div>
-								<div class="metric-info" v-show="showVitalsInfo">
+								<div class="metric-info" v-if="showVitalsInfo">
 									Cumulative Layout Shift measures the movement of visible elements within the viewport.
 									<a href="https://web.dev/cls/" target="_blank">Learn more</a>
 								</div>
@@ -100,7 +100,7 @@
 									{{ vitals.si.value|round }} ms
 								</div>
 								<div class="metric-value value-unavailable" v-else>—</div>
-								<div class="metric-info" v-show="showVitalsInfo">
+								<div class="metric-info" v-if="showVitalsInfo">
 									Speed Index shows how quickly the contents of a page are visibly populated.
 									<a href="https://web.dev/speed-index/" target="_blank">Learn more</a>
 								</div>

--- a/src/components/Tabs/Performance/PerformanceLog.vue
+++ b/src/components/Tabs/Performance/PerformanceLog.vue
@@ -7,7 +7,7 @@
 						<div class="log-message">
 							<div class="log-message-content">
 								<pretty-print :data="message.message"></pretty-print>
-								<div v-show="message.context && message.context.length">
+								<div v-if="message.context && message.context.length">
 									<pretty-print :data="message.context"></pretty-print>
 								</div>
 							</div>

--- a/src/components/Tabs/Performance/Profiler.vue
+++ b/src/components/Tabs/Performance/Profiler.vue
@@ -77,10 +77,10 @@
 							</p>
 
 							<p class="content-actions">
-								<a href="#" class="button" @click="$profiler.enableProfiling()" v-show="! $profiler.isProfiling">
+								<a href="#" class="button" @click="$profiler.enableProfiling()" v-if="! $profiler.isProfiling">
 									Enable profiler
 								</a>
-								<a href="#" class="button" @click="$profiler.disableProfiling()" v-show="$profiler.isProfiling">
+								<a href="#" class="button" @click="$profiler.disableProfiling()" v-if="$profiler.isProfiling">
 									Disable profiler
 								</a>
 							</p>

--- a/src/components/Tabs/Performance/Timeline.vue
+++ b/src/components/Tabs/Performance/Timeline.vue
@@ -97,7 +97,7 @@
 							</popover>
 						</div>
 					</td>
-					<td class="timeline-description">
+					<td v-if="showDetails" class="timeline-description">
 						<slot name="table-description" :item="group">
 							<div class="description-content">
 								<span class="description-tags" v-if="group.tags && group.tags.length">
@@ -110,17 +110,17 @@
 							</div>
 						</slot>
 					</td>
-					<td class="timeline-timing timing-total">{{group.duration|formatTiming}}</td>
-					<td class="timeline-timing">{{group.durationSelf|formatTiming}}</td>
-					<td class="timeline-timing">{{group.durationChildren|formatTiming('ms', group.condensed ? '' : '–')}}</td>
+					<td v-if="showDetails" class="timeline-timing timing-total">{{group.duration|formatTiming}}</td>
+					<td v-if="showDetails" class="timeline-timing">{{group.durationSelf|formatTiming}}</td>
+					<td v-if="showDetails" class="timeline-timing">{{group.durationChildren|formatTiming('ms', group.condensed ? '' : '–')}}</td>
 				</tr>
 
 				<tr class="timeline-size-monitor">
 					<td class="timeline-graph" ref="timelineChart"></td>
 					<td class="timeline-description"></td>
-					<td class="timeline-timing"></td>
-					<td class="timeline-timing"></td>
-					<td class="timeline-timing"></td>
+					<td v-if="showDetails" class="timeline-timing"></td>
+					<td v-if="showDetails" class="timeline-timing"></td>
+					<td v-if="showDetails" class="timeline-timing"></td>
 				</tr>
 			</template>
 		</details-table>

--- a/src/components/Tabs/PerformanceTab.vue
+++ b/src/components/Tabs/PerformanceTab.vue
@@ -1,5 +1,5 @@
 <template>
-	<div v-show="active">
+	<div v-if="active">
 		<div class="counters-row performance-metrics">
 			<div class="counter" v-if="$request.responseDurationRounded">
 				<div class="counter-value">{{$request.responseDurationRounded}} ms</div>
@@ -30,15 +30,15 @@
 				<a class="performance-tab" :class="{ 'active': isTabActive('client-side') }" href="#" @click.prevent="showTab('client-side')" v-if="isClientSideTabAvailable">
 					<icon name="smile"></icon> Client-side
 				</a>
-				<a class="performance-tab" :class="{ 'active': isTabActive('profiler') }" href="#" @click.prevent="showTab('profiler')" v-show="$platform.hasFeature('profiler')">
+				<a class="performance-tab" :class="{ 'active': isTabActive('profiler') }" href="#" @click.prevent="showTab('profiler')" v-if="$platform.hasFeature('profiler')">
 					<icon name="clock"></icon> Profiler
 				</a>
 			</div>
 
-			<performance-log :issues="performanceIssues" :slow-queries="databaseSlowQueries" v-show="isTabActive('issues')"></performance-log>
-			<timeline name="performance" :timeline="$request.timeline" :tags="timelineTags" v-show="isTabActive('timeline')"></timeline>
-			<performance-client-side :metrics="$request.clientMetrics" :vitals="$request.webVitals" v-show="isTabActive('client-side')"></performance-client-side>
-			<profiler v-show="isTabActive('profiler')"></profiler>
+			<performance-log :issues="performanceIssues" :slow-queries="databaseSlowQueries" v-if="isTabActive('issues')"></performance-log>
+			<timeline name="performance" :timeline="$request.timeline" :tags="timelineTags" v-if="isTabActive('timeline')"></timeline>
+			<performance-client-side :metrics="$request.clientMetrics" :vitals="$request.webVitals" v-if="isTabActive('client-side')"></performance-client-side>
+			<profiler v-if="isTabActive('profiler')"></profiler>
 		</div>
 	</div>
 </template>

--- a/src/components/Tabs/QueueJobTab.vue
+++ b/src/components/Tabs/QueueJobTab.vue
@@ -2,7 +2,7 @@
 	<div class="queue-job-tab">
 		<sidebar-section title="Payload" name="payload" v-if="$request.jobPayload">
 			<template slot="content" slot-scope="{ expanded }">
-				<div class="data-value" v-show="expanded">
+				<div class="data-value" v-if="expanded">
 					<pretty-print :data="$request.jobPayload" :expanded="true"></pretty-print>
 				</div>
 			</template>
@@ -10,7 +10,7 @@
 
 		<sidebar-section title="Queue" name="queue" v-if="$request.jobQueue">
 			<template slot="content" slot-scope="{ expanded }">
-				<div class="data-value" v-show="expanded">
+				<div class="data-value" v-if="expanded">
 					{{$request.jobQueue}}
 				</div>
 			</template>
@@ -18,7 +18,7 @@
 
 		<sidebar-section title="Connection" name="connection" v-if="$request.jobConnection">
 			<template slot="content" slot-scope="{ expanded }">
-				<div class="data-value" v-show="expanded">
+				<div class="data-value" v-if="expanded">
 					{{$request.jobConnection}}
 				</div>
 			</template>

--- a/src/components/Tabs/QueueTab.vue
+++ b/src/components/Tabs/QueueTab.vue
@@ -1,5 +1,5 @@
 <template>
-	<div v-show="active">
+	<div v-if="active">
 		<details-table title="Jobs" icon="clock" :columns="columns" :items="queueJobs" :filter="filter" filter-example="Underground.works name:GenerateInvoice queue:priority">
 			<template slot="body" slot-scope="{ items }">
 				<tr v-for="job, index in items" :key="`${$request.id}-${index}`">

--- a/src/components/Tabs/RedisTab.vue
+++ b/src/components/Tabs/RedisTab.vue
@@ -1,5 +1,5 @@
 <template>
-	<div v-show="active">
+	<div v-if="active">
 		<details-table title="Commands" icon="layers" :columns="columns" :items="$request.redisCommands" :filter="filter" filter-example="command:zrange connection:eshop file:StatsController.php duration:&gt;50">
 			<template slot="body" slot-scope="{ items }">
 				<tr v-for="query, index in items" :key="`${$request.id}-${index}`">

--- a/src/components/Tabs/RequestTab.vue
+++ b/src/components/Tabs/RequestTab.vue
@@ -1,28 +1,28 @@
 <template>
 	<div class="request-tab">
-		<sidebar-section title="Headers" name="headers" :items="headers" filter-example="text/html name:Accept" v-show="headers.length">
+		<sidebar-section title="Headers" name="headers" :items="headers" filter-example="text/html name:Accept" v-if="headers.length">
 		</sidebar-section>
 
-		<sidebar-section title="Data" name="data" :items="$request.requestData" filter-example="420 name:price" v-show="$request.requestData">
+		<sidebar-section title="Data" name="data" :items="$request.requestData" filter-example="420 name:price" v-if="$request.requestData">
 			<template v-slot:content="{ expanded }" v-if="! ($request.requestData instanceof Object)">
-				<div class="data-raw" v-show="expanded">
+				<div class="data-raw" v-if="expanded">
 					{{$request.requestData}}
 				</div>
 			</template>
 		</sidebar-section>
 
-		<sidebar-section title="GET data" name="getData" :items="$request.getData" filter-example="created_at name:orderBy" v-show="$request.getData.length">
+		<sidebar-section title="GET data" name="getData" :items="$request.getData" filter-example="created_at name:orderBy" v-if="$request.getData.length">
 		</sidebar-section>
 
-		<sidebar-section title="POST data" name="postData" :items="$request.postData" filter-example="&quot;Mike Jones&quot; name:name" v-show="$request.postData.length">
+		<sidebar-section title="POST data" name="postData" :items="$request.postData" filter-example="&quot;Mike Jones&quot; name:name" v-if="$request.postData.length">
 		</sidebar-section>
 
-		<sidebar-section title="Cookies" name="cookies" :items="$request.cookies" filter-example="&quot;Mike Jones&quot; name:name" v-show="$request.cookies.length">
+		<sidebar-section title="Cookies" name="cookies" :items="$request.cookies" filter-example="&quot;Mike Jones&quot; name:name" v-if="$request.cookies.length">
 		</sidebar-section>
 
-		<sidebar-section title="Middleware" name="middleware" :items="$request.middleware" filter-example="auth:admin" v-show="$request.middleware.length">
+		<sidebar-section title="Middleware" name="middleware" :items="$request.middleware" filter-example="auth:admin" v-if="$request.middleware.length">
 			<template slot="table" slot-scope="{ items, filter, filterExample, expanded }">
-				<details-table :columns="['Value']" :items="items" :filter="filter" :filter-example="filterExample" :no-header="true" :no-table-head="true" v-show="expanded">
+				<details-table :columns="['Value']" :items="items" :filter="filter" :filter-example="filterExample" :no-header="true" :no-table-head="true" v-if="expanded">
 					<template slot="header" slot-scope="{ filter }">
 					</template>
 					<template slot="body" slot-scope="{ items }">
@@ -34,7 +34,7 @@
 			</template>
 		</sidebar-section>
 
-		<sidebar-section title="Session" name="session" :items="$request.sessionData" filter-example="registration successful name:_token" v-show="$request.sessionData.length || $request.authenticatedUser">
+		<sidebar-section title="Session" name="session" :items="$request.sessionData" filter-example="registration successful name:_token" v-if="$request.sessionData.length || $request.authenticatedUser">
 			<template slot="above-table">
 				<div class="session-user" v-if="$request.authenticatedUser">
 					<icon name="user"></icon>

--- a/src/components/Tabs/RoutesTab.vue
+++ b/src/components/Tabs/RoutesTab.vue
@@ -1,5 +1,5 @@
 <template>
-	<div v-show="active">
+	<div v-if="active">
 		<details-table title="Routes" icon="map" :columns="columns" :items="$request.routes" :filter="filter" filter-example="OrderController method:post uri:order">
 			<template slot="body" slot-scope="{ items }">
 				<tr v-for="route, index in items" :key="`${$request.id}-${index}`">

--- a/src/components/Tabs/TestTab.vue
+++ b/src/components/Tabs/TestTab.vue
@@ -4,9 +4,9 @@
 			{{$request.testStatusMessage}}
 		</div>
 
-		<sidebar-section title="Asserts" name="asserts" :items="asserts" filter-example="text/html name:Accept" v-show="asserts.length">
+		<sidebar-section title="Asserts" name="asserts" :items="asserts" filter-example="text/html name:Accept" v-if="asserts.length">
 			<template slot="table" slot-scope="{ items, filter, filterExample, expanded }">
-				<details-table :columns="['Assert']" :items="items" :filter="filter" :filter-example="filterExample" :no-header="true" :no-table-head="true" v-show="expanded">
+				<details-table :columns="['Assert']" :items="items" :filter="filter" :filter-example="filterExample" :no-header="true" :no-table-head="true" v-if="expanded">
 					<template slot="body" slot-scope="{ items }">
 						<tr v-for="item, index in items" :key="`${$request.id}-${index}`">
 							<td class="value test-assert">

--- a/src/components/Tabs/UserTab.vue
+++ b/src/components/Tabs/UserTab.vue
@@ -1,5 +1,5 @@
 <template>
-	<div v-show="active">
+	<div v-if="active">
 		<div v-for="section, sectionIndex in userTab.sections" :key="`${$request.id}-${sectionIndex}`">
 			<div v-if="section.showAs == 'counters'" class="counters-row">
 				<div v-for="item, index in section.data" class="counter" :key="`${$request.id}-${index}`">

--- a/src/components/Tabs/ViewsTab.vue
+++ b/src/components/Tabs/ViewsTab.vue
@@ -1,5 +1,5 @@
 <template>
-	<div v-show="active">
+	<div v-if="active">
 		<timeline name="views" icon="image" :timeline="$request.viewsData">
 			<template slot="table-description" slot-scope="{ item }">
 				<div class="views-view-name">{{ item.description }}</div>

--- a/src/components/UI/DetailsTable.vue
+++ b/src/components/UI/DetailsTable.vue
@@ -24,7 +24,7 @@
 						<slot name="header" :filter="filter">
 							<th v-for="column, index in columns" @click="filter.sortBy(column.sortBy || column.toLowerCase())" :class="column.class">
 								{{ column.name || column }}
-								<icon v-show="filter.sortedBy == (column.sortBy || column.toLowerCase())" :name="filter.sortedDesc ? 'chevron-down' : 'chevron-up'"></icon>
+								<icon v-if="filter.sortedBy == (column.sortBy || column.toLowerCase())" :name="filter.sortedDesc ? 'chevron-down' : 'chevron-up'"></icon>
 							</th>
 						</slot>
 					</tr>

--- a/src/components/UI/Modal.vue
+++ b/src/components/UI/Modal.vue
@@ -1,6 +1,6 @@
 <template>
 	<transition name="modal">
-		<div class="modal-backdrop" @click.self="close" v-show="shown">
+		<div class="modal-backdrop" @click.self="close" v-if="shown">
 			<div class="modal">
 				<div class="modal-header">
 					<div class="header-title">

--- a/src/components/UI/SidebarSection.vue
+++ b/src/components/UI/SidebarSection.vue
@@ -17,12 +17,12 @@
 			</div>
 		</div>
 
-		<slot name="content" :expanded="expanded">
-			<div v-show="expanded">
+		<slot v-if="expanded" name="content" :expanded="expanded">
+			<div v-if="expanded">
 				<slot name="above-table"></slot>
 			</div>
 			<slot name="table" :items="items" :filter="filter" :filter-example="filterExample" :expanded="expanded">
-				<details-table :columns="['Key', 'Value']" :items="items" :filter="filter" :filter-example="filterExample" :no-header="true" :no-table-head="true" v-show="expanded">
+				<details-table :columns="['Key', 'Value']" :items="items" :filter="filter" :filter-example="filterExample" :no-header="true" :no-table-head="true" v-if="expanded">
 					<template slot="body" slot-scope="{ items }">
 						<tr v-for="item, index in items" :key="`${$request.id}-${index}`">
 							<td colspan="2">


### PR DESCRIPTION
Using v-show is almost never necessary and will cause a lot of uneeded DOM changes. This is especially noticeable when switching between requests, which for me always ended up with "Out of memory" issue. 

Now, switching between requests is a lot faster _(unless you are on a tab which uses `<popover>` on every row (I am going to fix those next)._

_EDIT: Still have out of memory issues. Will need to investigate some more._
_EDIT2: The issue with of memory have been resolved. Unrelated. Just logged to much data on events.__