### PR TITLE
Do not render popover before it should be visible

### DIFF
--- a/src/components/Tabs/Performance/Timeline.vue
+++ b/src/components/Tabs/Performance/Timeline.vue
@@ -48,7 +48,7 @@
 								</div>
 							</div>
 
-							<popover class="timeline-popover" ref="popovers">
+							<popover v-if="openPopover === index" class="timeline-popover" ref="popovers">
 								<div class="popover-event" :class="event.eventClass" v-for="event in group.events">
 									<div class="event-header">
 										<h1>{{event.name}}</h1>
@@ -146,6 +146,7 @@ export default {
 
 		hiddenTags: undefined,
 		presentedEvents: [],
+		openPopover: null,
 
 		filter: new Filter([
 			{ tag: 'duration', type: 'number' }
@@ -183,8 +184,12 @@ export default {
 			this.showDetails = ! this.showDetails
 		},
 
-		showPopover(index) {
-			this.$refs.popovers[index].toggle()
+		async showPopover(index) {
+			this.openPopover = index;
+
+			await this.$nextTick();
+
+			this.$refs.popovers[0].open();
 		},
 
 		async refreshEvents(e) {

--- a/src/components/UI/StackTrace.vue
+++ b/src/components/UI/StackTrace.vue
@@ -4,7 +4,7 @@
 			<shortened-text :full="trace ? shortPath : fullPath" @click.native="togglePopover($event)">{{shortPath}}</shortened-text>
 		</a>
 
-		<popover ref="popover" v-if="trace">
+		<popover ref="popover" v-if="trace && showPopover">
 			<div v-for="frame in trace" class="stack-frame" :class="{'is-vendor':frame.isVendor}">
 				<div class="stack-frame-call">{{ frame.call }}</div>
 				<div class="stack-frame-file">
@@ -31,11 +31,18 @@ export default {
 		fullPath() { return this.makeFullPath(this.file || this.trace[0]?.file, this.line || this.trace[0]?.line) },
 		shortPath() { return this.makeShortPath(this.file || this.trace[0]?.file, this.line || this.trace[0]?.line) }
 	},
+	data() {
+		return {
+			showPopover: false
+		}
+	},
 	methods: {
-		togglePopover($event) {
+		async togglePopover($event) {
 			if (! this.trace) return
 
 			$event.preventDefault()
+			this.showPopover = true;
+			await this.$nextTick();
 
 			this.$refs.popover.toggle()
 		},


### PR DESCRIPTION
Some tables include a popover on every row with lots of elements.
These popovers should not be added to DOM until they are needed.

Reduces render time when switching to the "Performance" tab and some others.