### PR TITLE
Vite Rollup failed to resolve import image

### DIFF
--- a/src/components/Settings/SettingsModal.vue
+++ b/src/components/Settings/SettingsModal.vue
@@ -19,17 +19,17 @@
 				<div class="controls">
 					<div class="appearance-controls">
 						<div class="option" :class="{'selected': $settings.global.appearance == 'auto'}" @click="setAppearance('auto')">
-							<img src="img/appearance-auto-icon.png">
+							<img src="/img/appearance-auto-icon.png">
 							Auto
 						</div>
 
 						<div class="option" :class="{'selected': $settings.global.appearance == 'light'}" @click="setAppearance('light')">
-							<img src="img/appearance-light-icon.png">
+							<img src="/img/appearance-light-icon.png">
 							Light
 						</div>
 
 						<div class="option" :class="{'selected': $settings.global.appearance == 'dark'}" @click="setAppearance('dark')">
-							<img src="img/appearance-dark-icon.png">
+							<img src="/img/appearance-dark-icon.png">
 							Dark
 						</div>
 					</div>


### PR DESCRIPTION
Hello! I have been tried to install app from source on Windows 10, npm v9.7.2, node v16.14.2.
Git clone
npm install
npm run build-chrome
and got an error

`
[vite]: Rollup failed to resolve import "img/appearance-auto-icon.png" from "src/components/Settings/SettingsModal.vue".
This is most likely unintended because it can break your application at runtime.
If you do want to externalize this module explicitly add it to
`build.rollupOptions.external`
error during build:
Error: [vite]: Rollup failed to resolve import "img/appearance-auto-icon.png" from "src/components/Settings/SettingsModal.vue".
This is most likely unintended because it can break your application at runtime.
If you do want to externalize this module explicitly add it to
`build.rollupOptions.external`
    at onRollupWarning (file:///C:/Users/fed_o/PhpstormProjects/clockwork-app/node_modules/vite/dist/node/chunks/dep-c842e491.js:46705:19)
    at onwarn (file:///C:/Users/fed_o/PhpstormProjects/clockwork-app/node_modules/vite/dist/node/chunks/dep-c842e491.js:46476:13)
    at Object.onwarn (file:///C:/Users/fed_o/PhpstormProjects/clockwork-app/node_modules/rollup/dist/es/shared/rollup.js:23263:13)
    at ModuleLoader.handleResolveId (file:///C:/Users/fed_o/PhpstormProjects/clockwork-app/node_modules/rollup/dist/es/shared/rollup.js:22158:26)
    at file:///C:/Users/fed_o/PhpstormProjects/clockwork-app/node_modules/rollup/dist/es/shared/rollup.js:22119:26
`
https://stackoverflow.com/questions/67696920/vite-rollup-failed-to-resolve-build-error
suggest adding leading slash for certainty