### PR TITLE
Support for collecting HTTP client requests

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -29,6 +29,8 @@ export default function createApp(global) {
 		}, {})
 	})
 
+	VueClipboard.config.autoSetContainer = true
+
 	app.use(VueClipboard)
 	app.use(vClickOutside)
 

--- a/src/components/Details/TabHandle.vue
+++ b/src/components/Details/TabHandle.vue
@@ -97,6 +97,7 @@ export default {
 	.tab-title {
 		overflow: hidden;
 		text-overflow: ellipsis;
+		white-space: nowrap;
 	}
 
 	.tab-badge {

--- a/src/components/RequestDetails.vue
+++ b/src/components/RequestDetails.vue
@@ -37,6 +37,7 @@
 				<performance-tab :active="activeTab == 'performance'"></performance-tab>
 				<views-tab :active="activeTab == 'views'" v-if="shownTabs.views"></views-tab>
 				<notifications-tab :active="activeTab == 'notifications'" v-if="shownTabs.notifications"></notifications-tab>
+				<http-requests-tab :active="activeTab == 'httpRequests'" v-if="shownTabs.notifications"></http-requests-tab>
 				<routes-tab :active="activeTab == 'routes'" v-if="shownTabs.routes"></routes-tab>
 				<user-tab v-for="userTab, index in $get($request, 'userData')" :key="`${$request.id}-${index}`" :user-tab="userTab" :active="activeTab == `user-${userTab.key}`"></user-tab>
 				<output-tab :active="activeTab == 'output'" v-if="shownTabs.output"></output-tab>
@@ -92,6 +93,7 @@ import TabBar from './Details/TabBar'
 import CacheTab from './Tabs/CacheTab'
 import DatabaseTab from './Tabs/DatabaseTab'
 import EventsTab from './Tabs/EventsTab'
+import HttpRequestsTab from './Tabs/HttpRequestsTab'
 import LogTab from './Tabs/LogTab'
 import ModelsTab from './Tabs/ModelsTab'
 import NotificationsTab from './Tabs/NotificationsTab'
@@ -109,8 +111,8 @@ export default {
 	name: 'RequestDetails',
 	components: {
 		CreditsModal, DetailsRequest, MessagesOverlay, SettingsModal, SharingModal, SharingDeleteModal, TabBar,
-		CacheTab, DatabaseTab, EventsTab, LogTab, ModelsTab, NotificationsTab, OutputTab, PerformanceTab, RedisTab,
-		QueueTab, RoutesTab, UserTab, ViewsTab
+		CacheTab, DatabaseTab, EventsTab, HttpRequestsTab, LogTab, ModelsTab, NotificationsTab, OutputTab, PerformanceTab,
+		RedisTab, QueueTab, RoutesTab, UserTab, ViewsTab
 	},
 	computed: {
 		tabs() {
@@ -123,6 +125,7 @@ export default {
 				{ text: 'Cache', name: 'cache', icon: 'paperclip', shown: this.shownTabs.cache },
 				{ text: 'Redis', name: 'redis', icon: 'layers', shown: this.shownTabs.redis },
 				{ text: 'Queue', name: 'queue', icon: 'clock', shown: this.shownTabs.queue },
+				{ text: 'HTTP Requests', name: 'httpRequests', icon: 'compass', shown: this.shownTabs.httpRequests },
 				{ text: 'Views', name: 'views', icon: 'image', shown: this.shownTabs.views },
 				{ text: 'Notifications', name: 'notifications', icon: 'mail', shown: this.shownTabs.notifications },
 				{ text: 'Routes', name: 'routes', icon: 'map', shown: this.shownTabs.routes }
@@ -153,6 +156,7 @@ export default {
 				events: this.$request?.events?.length > 0,
 				views: this.$request?.viewsData?.events.length > 0,
 				notifications: this.$request?.notifications?.length > 0,
+				httpRequests: this.$request?.httpRequests?.length > 0,
 				routes: this.$request?.routes?.length > 0,
 				output: this.$request?.commandOutput?.length > 0
 			}

--- a/src/components/RequestDetails.vue
+++ b/src/components/RequestDetails.vue
@@ -37,7 +37,7 @@
 				<performance-tab :active="activeTab == 'performance'"></performance-tab>
 				<views-tab :active="activeTab == 'views'" v-if="shownTabs.views"></views-tab>
 				<notifications-tab :active="activeTab == 'notifications'" v-if="shownTabs.notifications"></notifications-tab>
-				<http-requests-tab :active="activeTab == 'httpRequests'" v-if="shownTabs.notifications"></http-requests-tab>
+				<http-requests-tab :active="activeTab == 'httpRequests'" v-if="shownTabs.httpRequests"></http-requests-tab>
 				<routes-tab :active="activeTab == 'routes'" v-if="shownTabs.routes"></routes-tab>
 				<user-tab v-for="userTab, index in $get($request, 'userData')" :key="`${$request.id}-${index}`" :user-tab="userTab" :active="activeTab == `user-${userTab.key}`"></user-tab>
 				<output-tab :active="activeTab == 'output'" v-if="shownTabs.output"></output-tab>
@@ -125,7 +125,7 @@ export default {
 				{ text: 'Cache', name: 'cache', icon: 'paperclip', shown: this.shownTabs.cache },
 				{ text: 'Redis', name: 'redis', icon: 'layers', shown: this.shownTabs.redis },
 				{ text: 'Queue', name: 'queue', icon: 'clock', shown: this.shownTabs.queue },
-				{ text: 'HTTP Requests', name: 'httpRequests', icon: 'compass', shown: this.shownTabs.httpRequests },
+				{ text: 'HTTP', name: 'httpRequests', icon: 'compass', shown: this.shownTabs.httpRequests },
 				{ text: 'Views', name: 'views', icon: 'image', shown: this.shownTabs.views },
 				{ text: 'Notifications', name: 'notifications', icon: 'mail', shown: this.shownTabs.notifications },
 				{ text: 'Routes', name: 'routes', icon: 'map', shown: this.shownTabs.routes }

--- a/src/components/Tabs/HttpRequests/RequestModal.vue
+++ b/src/components/Tabs/HttpRequests/RequestModal.vue
@@ -1,0 +1,516 @@
+<template>
+	<modal icon="compass" title="HTTP Request" v-model:shown="requestLocal">
+        <div class="http-request-details" v-if="request">
+            <div class="details-columns">
+                <div class="details-request">
+                    <div class="request-info">
+                        <div @click="showRequestHeaders = ! showRequestHeaders" class="info-header">
+                            <div>
+                                <span class="request-method" :class="`method-${request.request.method.toLowerCase()}`">{{request.request.method}}</span> <span class="request-scheme">{{request.request.url.scheme}}</span><span class="request-host">{{request.request.url.host}}</span><span class="request-path">{{request.request.url.path}}</span><span class="request-query">{{request.request.url.query}}</span>
+                            </div>
+                            <ui-icon :name="showRequestHeaders ? 'chevron-down' : 'chevron-up'"></ui-icon>
+                        </div>
+                        
+                        <div class="info-headers" v-show="showRequestHeaders">
+                            <details-table :columns="['Key', 'Value']" :items="Object.entries(request.request.headers)" :no-header="true" :no-table-head="true">
+                                <template v-slot:body="{ items }">
+                                    <tr v-for="[ header, value ] in items" :key="`${$request.id}-${header}`">
+                                        <td colspan="2">
+                                            <div class="key">{{header}}</div>
+                                            <div class="value">{{value.join(', ')}}</div>
+                                        </td>
+                                    </tr>
+                                </template>
+                            </details-table>
+                        </div>
+                    </div>
+                    
+                    <div class="request-content">
+                        <div class="request-content-header">
+                            <div v-if="request.stats?.size.upload !== null && request.stats?.size.upload !== undefined" class="stats-item" title="Upload Size">
+                                <ui-icon name="upload-cloud"></ui-icon>
+                                {{formatBytesSize(request.stats.size.upload)}}
+                            </div>
+                            <div v-if="request.stats?.speed.upload !== null && request.stats?.speed.upload !== undefined" class="stats-item" title="Upload Speed">
+                                <ui-icon name="zap"></ui-icon>
+                                {{formatBytesSpeed(request.stats.speed.upload)}}
+                            </div>
+                            <div v-if="request.stats?.hosts.local" class="stats-item">
+                                {{request.stats.hosts.local.ip}}:{{request.stats.hosts.local.port}}
+                            </div>
+                        
+                            <a v-if="request.request.body" @click="showRawRequestBody = ! showRawRequestBody" href="#" class="header-action" :class="{ 'active': showRawRequestBody }" title="Show raw request body">
+                                Raw
+                            </a>
+                        </div>
+                    
+                        <div class="request-content-content">
+                            <div v-if="! request.request.content || ! Object.values(request.request.content).length" class="request-content-empty">
+                                No request body.
+                            </div>
+                            
+                            <pretty-print v-else-if="! showRawRequestBody" :data="request.request.content" :expanded="true"></pretty-print>
+                            
+                            <code v-else v-html="request.request.body"></code>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="details-response">
+                    <div v-if="request.response" class="response-info">
+                        <div @click="showResponseHeaders = ! showResponseHeaders" class="info-header" :class="{ 'client-error': request.response.status >= 400 && request.response.status <= 499, 'server-error': request.response.status >= 500 && request.response.status <= 599 }">
+                            <div class="header-status">
+                                <span class="status-code">{{request.response.status}}</span>
+                                <span class="status-message">
+                                    {{request.response.statusMessage}}
+                                </span>
+                            </div>
+                            <span class="status-version" v-if="request.stats.version">
+                                    HTTP{{request.stats.version}}
+                            </span>
+                            <ui-icon :name="showResponseHeaders ? 'chevron-down' : 'chevron-up'"></ui-icon>
+                        </div>
+                        
+                        <div class="info-headers" v-show="showResponseHeaders">
+                            <details-table :columns="['Key', 'Value']" :items="Object.entries(request.response.headers)" :no-header="true" :no-table-head="true">
+                                <template v-slot:body="{ items }">
+                                    <tr v-for="[ header, value ] in items" :key="`${$request.id}-${header}`">
+                                        <td colspan="2">
+                                            <div class="key">{{header}}</div>
+                                            <div class="value">{{value.join(', ')}}</div>
+                                        </td>
+                                    </tr>
+                                </template>
+                            </details-table>
+                        </div>
+                    </div>
+                    
+                    <div v-if="request.response" class="response-content">
+                        <div class="response-content-header">
+                            <div v-if="request.stats.size.download !== null" class="stats-item" title="Download Size">
+                                <ui-icon name="download-cloud"></ui-icon>
+                                {{formatBytesSize(request.stats.size.download)}}
+                            </div>
+                            <div v-if="request.stats.speed.download !== null" class="stats-item" title="Download Speed">
+                                <ui-icon name="zap"></ui-icon>
+                                {{formatBytesSpeed(request.stats.speed.download)}}
+                            </div>
+                            <div v-if="request.stats.hosts.remote" class="stats-item">
+                                {{request.stats.hosts.remote.ip}}:{{request.stats.hosts.remote.port}}
+                            </div>
+
+                            <a v-if="request.response.body && hasJsonResponse" @click="showRawResponseBody = ! showRawResponseBody" href="#" class="header-action" :class="{ 'active': showRawResponseBody }" title="Show raw response body">
+                                Raw
+                            </a>
+                        </div>
+
+                        <div class="response-content-content">
+                            <div v-if="(! request.response.content || ! Object.values(request.response.content).length) && ! request.response.body" class="response-content-empty">
+                                No response body.
+                            </div>
+
+                            <pretty-print v-else-if="hasJsonResponse && ! showRawResponseBody" :data="request.response.content" :expanded="true"></pretty-print>
+
+                            <code v-else-if="hasJsonResponse" v-html="request.response.body"></code>
+                            
+                            <iframe v-else ref="responseContent" :srcdoc="request.response.body"></iframe>
+                        </div>
+                    </div>
+                    
+                    <div v-if="! request.response" class="response-error">
+                        <p>No response.</p>
+                        <p v-if="request.error">({{request.error}})</p>
+                    </div>
+                </div>
+            </div>
+            
+            <div v-if="request.stats?.timing" class="request-performance">
+                <performance-chart :metrics="timings"></performance-chart>
+                
+                <div class="performance-timings">
+                    <div v-for="timing in timings" class="timings-timing">
+                        <div class="timing-color" :class="timing.color"></div>
+                        {{timing.name}}
+                        <div class="timing-value" :title="`${timing.value} ms`">{{Math.round(timing.value)}} ms</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </modal>
+</template>
+
+<script>
+import DetailsTable from '../../UI/DetailsTable'
+import Modal from '../../UI/Modal'
+import PerformanceChart from '../Performance/PerformanceChart'
+import PrettyPrint from '../../UI/PrettyPrint'
+import UiIcon from '../../UI/Icon'
+
+export default {
+    name: 'HttpRequestModal',
+    components: { DetailsTable, Modal, PerformanceChart, PrettyPrint, UiIcon },
+    props: [ 'request' ],
+    data: () => ({
+        showRequestHeaders: false,
+        showResponseHeaders: false,
+        showRawRequestBody: false,
+        showRawResponseBody: false
+    }),
+    computed: {
+        requestLocal: {
+            get() { return this.request },
+            set(val) { this.$emit('update:request', val) }
+        },
+        
+        timings() {
+            return this.request.stats.timing ? [
+                { name: 'Lookup', value: this.request.stats.timing.lookup, color: 'red' },
+                { name: 'Connect', value: this.request.stats.timing.connect, color: 'purple' },
+                { name: 'Waiting', value: this.request.stats.timing.waiting, color: 'blue' },
+                { name: 'Transfer', value: this.request.stats.timing.transfer, color: 'green' }
+            ] : []
+        }
+    },
+    methods: {
+        formatBytesSize(value) {
+            if (! value) return '0 B'
+            
+            const units = [ 'B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB' ]
+            const i = Math.floor(Math.log(value) / Math.log(1024))
+
+            return `${Math.round(value / Math.pow(1024, i))} ${units[i]}`
+        },
+        
+        formatBytesSpeed(value) {
+            return `${this.formatBytesSize(value)}/s`
+        }
+    }
+}
+</script>
+
+<style lang="scss">
+@import '../../../mixins.scss';
+
+.http-request-details {
+    font-size: 13px;
+    margin: 0 auto;
+    max-width: 820px;
+    width: 100vw;
+    
+    .details-columns {
+        align-items: flex-start;
+        display: flex;
+        gap: 20px;
+        margin-top: 20px;
+    }
+    
+    .request-info, .response-info, .request-content, .response-content, .response-error {
+        background: hsl(240, 20, 99);
+        border: 1px solid hsl(240, 20, 90);
+        border-radius: 8px;
+        box-shadow: 0 2px 2px 0 hsl(240, 20, 95);
+        padding: 10px;
+    }
+    
+    .request-content, .response-content {
+        margin-top: 16px;
+        
+        .request-content-header, .response-content-header {
+            align-items: center;
+            display: flex;
+            margin-bottom: 10px;
+
+            .stats-item {
+                background: hsl(240, 20, 96);
+                border-radius: 8px;
+                color: grey;
+                font-size: 12px;
+                margin-right: 5px;
+                padding: 4px 8px;
+
+                @include dark {
+                    background: hsl(240, 2, 13);
+                    color: rgb(118, 118, 118);
+                }
+
+                .ui-icon {
+                    margin-right: 2px;
+                }
+            }
+
+            .header-action {
+                align-items: center;
+                border-radius: 4px;
+                display: flex;
+                font-size: 12px;
+                height: 24px;
+                justify-content: center;
+                margin-left: auto;
+                padding: 0 8px;
+                text-decoration: none;
+
+                @include dark {
+                    color: rgb(158, 158, 158);
+                }
+
+                &:hover {
+                    color: rgb(37, 140, 219);
+
+                    @include dark {
+                        color: hsl(31, 98%, 42%);
+                    }
+                }
+
+                &.active {
+                    background: rgb(39, 134, 243);
+                    color: #f5f5f5;
+
+                    @include dark {
+                        background: hsl(31, 98%, 42%);
+                        color: #fff;
+                    }
+                }
+            }
+        }
+
+        .request-content-empty, .response-content-empty {
+            color: gray;
+            padding: 20px 0;
+            text-align: center;
+
+            @include dark {
+                color: rgb(118, 118, 118);
+            }
+        }
+        
+        .request-content-content, .response-content-content {
+            padding: 8px 4px;
+            
+            code {
+                font-size: 12px;
+            }
+            
+            iframe {
+                border: 1px solid hsl(240, 20, 90);
+                border-radius: 8px;
+                min-height: 30vh;
+                width: 100%;
+            }
+        }
+    }
+    
+    .details-request {
+        flex: 1;
+
+        @include dark {
+            background: hsl(240, 2, 15);
+            box-shadow: 0 0 0px 1px #15151e, 0 2px 2px 0 #15151e;
+        }
+        
+        .info-header {
+            font-size: 15px;
+
+            .request-method {
+                color: grey;
+                font-weight: 500;
+
+                @include dark {
+                    color: rgb(118, 118, 118);
+                }
+                
+                &.method-get, &.method-head {
+                    color: hsl(109, 52%, 45%);
+                    @include dark { color: hsl(109, 47%, 50%); }
+                }
+                
+                &.method-post, &.method-put, &.method-patch {
+                    color: hsl(212, 89%, 55%);
+                    @include dark { color: hsl(212, 83%, 60%); }
+                }
+
+                &.method-delete {
+                    color: hsl(359, 57%, 55%);
+                    @include dark { color: hsl(359, 52%, 60%); }
+                }
+            }
+
+            .request-host { font-weight: 600; }
+            .request-query { color: grey; }
+        }
+    }
+
+    .details-response {
+        flex: 1;
+        
+        @include dark {
+            background: hsl(240, 2, 15);
+            box-shadow: 0 0 0px 1px #15151e, 0 2px 2px 0 #15151e;
+        }
+        
+        .info-header {
+            &.client-error {
+                color: #a85919;
+                .status-code { background: #fffae2; }
+
+                @include dark {
+                    color: #fad89f;
+                    .status-code { background: #382f00; }
+                }
+            }
+
+            &.server-error {
+                color: #c51f24;
+                background: #ffebeb;
+
+                @include dark {
+                    color: #ed797a;
+                    background: #380000;
+                }
+            }            
+        }
+        
+        .header-status {
+            color: #586336;
+            flex: 1;
+            font-size: 14px;
+            
+            @include dark {
+                color: hsla(75, 90%, 80%, 1);
+            }
+            
+            .status-code {
+                background: hsl(76, 47%, 86%);
+                border-radius: 8px;
+                padding: 2px 6px;
+                text-transform: uppercase;
+
+                @include dark {
+                    background: hsla(76, 100%, 11%, 1);
+                }
+            }
+            
+            .status-message {
+                margin-left: 5px;
+            }
+        }
+        
+        .status-version {
+            color: grey;
+            font-size: 12px;
+            margin-right: 5px;
+            
+            @include dark {
+                color: rgb(118, 118, 118);
+            }
+        }
+    }
+    
+    .info-header {
+        align-items: center;
+        cursor: pointer;
+        display: flex;
+        padding: 4px;
+        
+        .ui-icon {
+            margin-left: auto;
+        }
+    }
+    
+    .info-headers {
+        margin-top: 5px;
+        
+        .details-table {
+            border-radius: 0;
+            box-shadow: none;
+            margin-bottom: 0;
+            padding-bottom: 0;
+
+            @include dark {
+                box-shadow: none;
+            }
+
+            td {
+                border-radius: 5px;
+                vertical-align: top;
+
+                .key {
+                    font-size: 11px;
+                    font-weight: 600;
+                    margin-bottom: 3px;
+                    white-space: nowrap;
+                }
+
+                .value {
+                    word-break: break-all;
+                }
+            }
+        }
+    }
+    
+    .request-performance {
+        margin-top: 25px;
+        
+        .performance-chart {
+            margin-bottom: 10px;
+        }
+        
+        .performance-timings {
+            display: flex;
+            gap: 12px;
+            
+            .timings-timing {
+                align-items: center;
+                color: gray;
+                display: flex;
+                gap: 5px;
+                
+                @include dark {
+                    color: rgb(118, 118, 118);
+                }
+                
+                .timing-color {
+                    border-radius: 50%;
+                    height: 10px;
+                    width: 10px;
+                    
+                    &.blue {
+                        background-color: hsl(212, 89%, 55%);
+                        @include dark { background-color: hsl(212, 76%, 60%); }
+                    }
+
+                    &.red {
+                        background-color: hsl(359, 57%, 55%);
+                        @include dark { background-color: hsl(359, 45%, 60%); }
+                    }
+
+                    &.green {
+                        background-color: hsl(109, 52%, 45%);
+                        @include dark { background-color: hsl(109, 40%, 50%); }
+                    }
+
+                    &.purple {
+                        background-color: hsl(273, 57%, 55%);
+                        @include dark { background-color: hsl(273, 45%, 60%); }
+                    }
+                }
+                
+                .timing-value {
+                    font-weight: 600;
+                }
+            }
+        }
+    }
+    
+    .response-error {
+        align-items: center;
+        color: gray;
+        display: flex;
+        flex-direction: column;
+        padding: 20px 0;
+        
+        @include dark {
+            color: rgb(118, 118, 118);
+        }
+    }
+}
+</style>

--- a/src/components/Tabs/HttpRequests/RequestModal.vue
+++ b/src/components/Tabs/HttpRequests/RequestModal.vue
@@ -183,11 +183,11 @@ export default {
         },
         
         hasRequestContent() {
-            return (this.request.request.content && Object.values(this.request.request.content).length) || this.request.body
+            return (this.request.request.content && Object.values(this.request.request.content).length) || this.request.request.body
         },
 
         hasResponseContent() {
-            return (this.request.response.content && Object.values(this.request.response.content).length) || this.response.body
+            return (this.request.response?.content && Object.values(this.request.response?.content).length) || this.request.response?.body
         },
 
         hasJsonResponse() {
@@ -195,12 +195,10 @@ export default {
         },
 
         copyRequestContent() {
-            console.log(this.request.request.body || JSON.stringify(this.request.request.content))
             this.$copyText(this.request.request.body || JSON.stringify(this.request.request.content))
         },
 
         copyResponseContent() {
-            console.log(this.request.response.body || JSON.stringify(this.request.response.content))
             this.$copyText(this.request.response.body || JSON.stringify(this.request.response.content))
         },
 

--- a/src/components/Tabs/HttpRequestsTab.vue
+++ b/src/components/Tabs/HttpRequestsTab.vue
@@ -1,0 +1,157 @@
+<template>
+	<div v-show="active">
+		<details-table title="HTTP Requests" icon="compass" :columns="[ 'Request', 'Status', 'Duration', '' ]" :items="$request.httpRequests" :filter="filter" filter-example="&quot;/users&quot; method:post" class="http-requests-requests">
+			<template v-slot:body="{ items }">
+				<template v-for="request, index in items" :key="`${$request.id}-http-requests-${index}`">
+					<tr>
+						<td class="request-request">
+							<div class="request-content">
+								<div class="content-text">
+									<span class="text-method" :class="`method-${request.request.method.toLowerCase()}`">{{request.request.method}}</span> <span class="text-scheme">{{request.request.url.scheme}}</span><span class="text-host">{{request.request.url.host}}</span><span class="text-path">{{request.request.url.path}}</span><span class="text-query">{{request.request.url.query}}</span>
+								</div>
+	                            <stack-trace class="content-trace" :trace="request.trace"></stack-trace>
+							</div>
+                        </td>
+						<td class="request-status">
+							<span :class="{ 'status-text': request.response?.status, 'client-error': request.response?.status >= 400 && request.response?.status <= 499, 'server-error': request.response?.status >= 500 && request.response?.status <= 599 }">{{request.response?.status || '—'}}</span>
+						</td>
+						<td class="request-duration">
+							{{request.duration ? `${$round(request.duration, 1)} ms` : '—'}}
+						</td>
+						<td class="request-actions">
+							<a href="#" @click.prevent="showRequest = request" title="Show request">
+								<icon name="search"></icon>
+							</a>
+						</td>
+					</tr>
+				</template>
+			</template>
+		</details-table>
+
+		<request-modal v-model:request="showRequest"></request-modal>
+	</div>
+</template>
+
+<script>
+import DetailsTable from '../UI/DetailsTable'
+import RequestModal from './HttpRequests/RequestModal'
+import PrettyPrint from '../UI/PrettyPrint'
+import StackTrace from '../UI/StackTrace'
+
+import Filter from '../../features/filter'
+
+export default {
+	name: 'httpRequestsTab',
+	components: { DetailsTable, PrettyPrint, RequestModal, StackTrace },
+	props: [ 'active' ],
+	data: () => ({
+		filter: new Filter([
+			{ tag: 'to' }
+		]),
+
+		showRequest: null
+	})
+}
+</script>
+
+<style lang="scss">
+@import '../../mixins.scss';
+
+.http-requests-requests {
+	.request-request {
+		width: 100%;
+
+		.request-content {
+			display: flex;
+			flex-wrap: wrap;
+			width: 100%;
+			
+			.content-text {
+				font-size: 13px;
+				
+				.text-method {
+					color: grey;
+					font-weight: 500;
+					
+					@include dark {
+						color: rgb(118, 118, 118);
+					}
+					
+					&.method-get, &.method-head {
+						color: hsl(109, 52%, 45%);
+						@include dark { color: hsl(109, 47%, 50%); }
+					}
+
+					&.method-post, &.method-put, &.method-patch {
+						color: hsl(212, 89%, 55%);
+						@include dark { color: hsl(212, 83%, 60%); }
+					}
+
+					&.method-delete {
+						color: hsl(359, 57%, 55%);
+						@include dark { color: hsl(359, 52%, 60%); }
+					}
+				}
+				
+				.text-host { font-weight: 500; }
+				.text-query { color: grey; }
+			}
+
+			.content-trace {
+				margin-left: auto;
+			}
+		}
+	}
+	
+	.request-duration {
+		text-align: right;
+		white-space: nowrap;
+	}
+
+	.request-status {
+		text-align: center;
+		
+		.status-text {
+			background: hsl(76, 47%, 86%);
+			border-radius: 8px;
+			color: #586336;
+			font-size: 11px;
+			padding: 2px 6px;
+			text-transform: uppercase;
+			
+			@include dark {
+				background: hsla(76, 100%, 11%, 1);
+				color: hsla(75, 90%, 80%, 1);
+			}
+
+			&.client-error {
+				background: #fffae2;
+				color: #a85919;
+
+				@include dark {
+					background: #382f00;
+					color: #fad89f;
+				}
+			}
+
+			&.server-error {
+				background: #ffebeb;
+				color: #c51f24;
+
+				@include dark {
+					background: #380000;
+					color: #ed797a;
+				}
+			}
+		}
+	}
+	
+	.request-actions {
+		white-space: nowrap;
+
+		a {
+			margin-left: 5px;
+		}
+	}
+}
+</style>

--- a/src/components/Tabs/Performance/PerformanceChart.vue
+++ b/src/components/Tabs/Performance/PerformanceChart.vue
@@ -64,6 +64,7 @@ $performance-chart-colors-dark: (
 	display: flex;
 	height: 6px;
 	margin: 0 auto 20px;
+	overflow: hidden;
 	width: calc(100% - 2px);
 
 	@include dark {

--- a/src/components/Tabs/PerformanceTab.vue
+++ b/src/components/Tabs/PerformanceTab.vue
@@ -67,6 +67,7 @@ export default {
 			{ tag: 'cacheQueries', icon: 'paperclip', title: 'Cache' },
 			{ tag: 'redisCommands', icon: 'layers', title: 'Redis' },
 			{ tag: 'queueJobs', icon: 'clock', title: 'Queue' },
+			{ tag: 'httpRequests', icon: 'compass', title: 'HTTP Requests' },
 			{ tag: 'views', icon: 'image', title: 'Views' },
 			{ tag: 'notifications', icon: 'mail', title: 'Notifications' }
 		]

--- a/src/components/UI/Icon.vue
+++ b/src/components/UI/Icon.vue
@@ -12,6 +12,7 @@ import ChevronDownIcon from 'feather-icons/dist/icons/chevron-down.svg?raw'
 import ChevronLeftIcon from 'feather-icons/dist/icons/chevron-left.svg?raw'
 import ChevronRightIcon from 'feather-icons/dist/icons/chevron-right.svg?raw'
 import ChevronUpIcon from 'feather-icons/dist/icons/chevron-up.svg?raw'
+import ClipboardIcon from 'feather-icons/dist/icons/clipboard.svg?raw'
 import ClockIcon from 'feather-icons/dist/icons/clock.svg?raw'
 import CompassIcon from 'feather-icons/dist/icons/compass.svg?raw'
 import CpuIcon from 'feather-icons/dist/icons/cpu.svg?raw'
@@ -53,11 +54,11 @@ import ZapIcon from 'feather-icons/dist/icons/zap.svg?raw'
 
 let icons = {
 	ActivityIcon, AlertCircleIcon, AlertTriangleIcon, ArrowDownCircleIcon, CheckCircleIcon, ChevronDownIcon,
-	ChevronLeftIcon, ChevronRightIcon, ChevronUpIcon, ClockIcon, CompassIcon, CpuIcon, DatabaseIcon, DiscIcon,
-	DownloadCloudIcon, Edit2Icon, GithubIcon, HashIcon, HeartIcon, HelpCircleIcon, ImageIcon, InfoIcon, LayersIcon,
-	LinkIcon, ListIcon, LockIcon, MailIcon, MapIcon, MenuIcon, PaperclipIcon, PercentIcon, PieChartIcon, SearchIcon,
-	SettingsIcon, ShareIcon, SlashIcon, SmileIcon, StarIcon, TerminalIcon, Trash2Icon, TwitterIcon, UploadCloudIcon,
-	UserIcon, UsersIcon, XIcon, XCircleIcon, ZapIcon
+	ChevronLeftIcon, ChevronRightIcon, ChevronUpIcon, ClipboardIcon, ClockIcon, CompassIcon, CpuIcon, DatabaseIcon,
+	DiscIcon, DownloadCloudIcon, Edit2Icon, GithubIcon, HashIcon, HeartIcon, HelpCircleIcon, ImageIcon, InfoIcon,
+	LayersIcon, LinkIcon, ListIcon, LockIcon, MailIcon, MapIcon, MenuIcon, PaperclipIcon, PercentIcon, PieChartIcon,
+	SearchIcon, SettingsIcon, ShareIcon, SlashIcon, SmileIcon, StarIcon, TerminalIcon, Trash2Icon, TwitterIcon,
+	UploadCloudIcon, UserIcon, UsersIcon, XIcon, XCircleIcon, ZapIcon
 }
 
 export default {

--- a/src/components/UI/Icon.vue
+++ b/src/components/UI/Icon.vue
@@ -13,9 +13,11 @@ import ChevronLeftIcon from 'feather-icons/dist/icons/chevron-left.svg?raw'
 import ChevronRightIcon from 'feather-icons/dist/icons/chevron-right.svg?raw'
 import ChevronUpIcon from 'feather-icons/dist/icons/chevron-up.svg?raw'
 import ClockIcon from 'feather-icons/dist/icons/clock.svg?raw'
+import CompassIcon from 'feather-icons/dist/icons/compass.svg?raw'
 import CpuIcon from 'feather-icons/dist/icons/cpu.svg?raw'
 import DatabaseIcon from 'feather-icons/dist/icons/database.svg?raw'
 import DiscIcon from 'feather-icons/dist/icons/disc.svg?raw'
+import DownloadCloudIcon from 'feather-icons/dist/icons/download-cloud.svg?raw'
 import Edit2Icon from 'feather-icons/dist/icons/edit-2.svg?raw'
 import GithubIcon from 'feather-icons/dist/icons/github.svg?raw'
 import HashIcon from 'feather-icons/dist/icons/hash.svg?raw'
@@ -42,6 +44,7 @@ import StarIcon from 'feather-icons/dist/icons/star.svg?raw'
 import TerminalIcon from 'feather-icons/dist/icons/terminal.svg?raw'
 import Trash2Icon from 'feather-icons/dist/icons/trash-2.svg?raw'
 import TwitterIcon from 'feather-icons/dist/icons/twitter.svg?raw'
+import UploadCloudIcon from 'feather-icons/dist/icons/upload-cloud.svg?raw'
 import UserIcon from 'feather-icons/dist/icons/user.svg?raw'
 import UsersIcon from 'feather-icons/dist/icons/users.svg?raw'
 import XIcon from 'feather-icons/dist/icons/x.svg?raw'
@@ -50,10 +53,11 @@ import ZapIcon from 'feather-icons/dist/icons/zap.svg?raw'
 
 let icons = {
 	ActivityIcon, AlertCircleIcon, AlertTriangleIcon, ArrowDownCircleIcon, CheckCircleIcon, ChevronDownIcon,
-	ChevronLeftIcon, ChevronRightIcon, ChevronUpIcon, ClockIcon, CpuIcon, DatabaseIcon, DiscIcon, Edit2Icon, GithubIcon,
-	HashIcon, HeartIcon, HelpCircleIcon, ImageIcon, InfoIcon, LayersIcon, LinkIcon, ListIcon, LockIcon, MailIcon,
-	MapIcon, MenuIcon, PaperclipIcon, PercentIcon, PieChartIcon, SearchIcon, SettingsIcon, ShareIcon, SlashIcon,
-	SmileIcon, StarIcon, TerminalIcon, Trash2Icon, TwitterIcon, UserIcon, UsersIcon, XIcon, XCircleIcon, ZapIcon
+	ChevronLeftIcon, ChevronRightIcon, ChevronUpIcon, ClockIcon, CompassIcon, CpuIcon, DatabaseIcon, DiscIcon,
+	DownloadCloudIcon, Edit2Icon, GithubIcon, HashIcon, HeartIcon, HelpCircleIcon, ImageIcon, InfoIcon, LayersIcon,
+	LinkIcon, ListIcon, LockIcon, MailIcon, MapIcon, MenuIcon, PaperclipIcon, PercentIcon, PieChartIcon, SearchIcon,
+	SettingsIcon, ShareIcon, SlashIcon, SmileIcon, StarIcon, TerminalIcon, Trash2Icon, TwitterIcon, UploadCloudIcon,
+	UserIcon, UsersIcon, XIcon, XCircleIcon, ZapIcon
 }
 
 export default {

--- a/src/support/http-codes.json
+++ b/src/support/http-codes.json
@@ -1,0 +1,452 @@
+{
+  "1xx": {
+    "code": "1xx",
+    "message": "Information",
+    "description": "1xx codes are often interim responses for sharing connection status information. Not intended for final request or response action."
+  },
+  "100": {
+    "code": 100,
+    "message": "Continue",
+    "description": "The server has received the request headers, and the client should proceed to send the request body."
+  },
+  "101": {
+    "code": 101,
+    "message": "Switching Protocols",
+    "description": "The requester has asked the server to switch protocols."
+  },
+  "102": {
+    "code": 102,
+    "message": "Processing",
+    "description": "This code indicates that the server has received and is processing the request, but no response is available yet. This prevents the client from timing out and assuming the request was lost."
+  },
+  "103": {
+    "code": 103,
+    "message": "Early Hints",
+    "description": "Used to return some response headers before final HTTP message."
+  },
+  "2xx": {
+    "code": "2xx",
+    "message": "Successful",
+    "description": "2xx codes indicate successful responses usually this means the action requested by the client was received, understood and accepted successfully."
+  },
+  "200": {
+    "code": 200,
+    "message": "OK",
+    "description": "The request is OK (this is the standard response for successful HTTP requests)."
+  },
+  "201": {
+    "code": 201,
+    "message": "Created",
+    "description": "The request has been fulfilled, and a new resource is created."
+  },
+  "202": {
+    "code": 202,
+    "message": "Accepted",
+    "description": "The request has been accepted for processing, but the processing has not been completed."
+  },
+  "203": {
+    "code": 203,
+    "message": "Non-Authoritative Information",
+    "description": "The request has been successfully processed, but is returning information that may be from another source."
+  },
+  "204": {
+    "code": 204,
+    "message": "No Content",
+    "description": "The request has been successfully processed, but is not returning any content."
+  },
+  "205": {
+    "code": 205,
+    "message": "Reset Content",
+    "description": "The request has been successfully processed, but is not returning any content, and requires that the requester reset the document view."
+  },
+  "206": {
+    "code": 206,
+    "message": "Partial Content",
+    "description": "The server is delivering only part of the resource due to a range header sent by the client."
+  },
+  "207": {
+    "code": 207,
+    "message": "Multi-Status",
+    "description": "The message body that follows is by default an XML message and can contain a number of separate response codes, depending on how many sub-requests were made."
+  },
+  "208": {
+    "code": 208,
+    "message": "Already Reported",
+    "description": "The members of a DAV binding have already been enumerated in a preceding part of the (multistatus) response, and are not being included again."
+  },
+  "218": {
+    "code": 218,
+    "message": "This is fine (Apache Web Server)",
+    "description": "Used as a catch-all error condition for allowing response bodies to flow through Apache when ProxyErrorOverride is enabled."
+  },
+  "226": {
+    "code": 226,
+    "message": "IM Used",
+    "description": "The server has fulfilled a request for the resource, and the response is a representation of the result of one or more instance-manipulations applied to the current instance."
+  },
+  "3xx": {
+    "code": "3xx",
+    "message": "Redirection",
+    "description": "3xx codes are a class of responses that suggest the User-Agent must follow another course of action to obtain the complete requested resource."
+  },
+  "300": {
+    "code": 300,
+    "message": "Multiple Choices",
+    "description": "A link list. The user can select a link and go to that location. Maximum five addresses."
+  },
+  "301": {
+    "code": 301,
+    "message": "Moved Permanently",
+    "description": "The requested page has moved to a new URL."
+  },
+  "302": {
+    "code": 302,
+    "message": "Found",
+    "description": "The requested page has moved temporarily to a new URL."
+  },
+  "303": {
+    "code": 303,
+    "message": "See Other",
+    "description": "The requested page can be found under a different URL."
+  },
+  "304": {
+    "code": 304,
+    "message": "Not Modified",
+    "description": "Indicates the requested page has not been modified since last requested."
+  },
+  "306": {
+    "code": 306,
+    "message": "Switch Proxy",
+    "description": "No longer used. Originally meant \"Subsequent requests should use the specified proxy.\""
+  },
+  "307": {
+    "code": 307,
+    "message": "Temporary Redirect",
+    "description": "The requested page has moved temporarily to a new URL."
+  },
+  "308": {
+    "code": 308,
+    "message": "Resume Incomplete",
+    "description": "Used in the resumable requests proposal to resume aborted PUT or POST requests."
+  },
+  "4xx": {
+    "code": "4xx",
+    "message": "Client Error",
+    "description": "4xx codes generally are error responses specifying an issue at the client’s end. Potentially a network issue."
+  },
+  "400": {
+    "code": 400,
+    "message": "Bad Request",
+    "description": "The request cannot be fulfilled due to bad syntax."
+  },
+  "401": {
+    "code": 401,
+    "message": "Unauthorized",
+    "description": "The request was a legal request, but the server is refusing to respond to it. For use when authentication is possible but has failed or not yet been provided."
+  },
+  "402": {
+    "code": 402,
+    "message": "Payment Required",
+    "description": "Not yet implemented by RFC standards, but reserved for future use."
+  },
+  "403": {
+    "code": 403,
+    "message": "Forbidden",
+    "description": "The request was a legal request, but the server is refusing to respond to it."
+  },
+  "404": {
+    "code": 404,
+    "message": "Not Found",
+    "description": "The requested page could not be found but may be available again in the future."
+  },
+  "405": {
+    "code": 405,
+    "message": "Method Not Allowed",
+    "description": "A request was made of a page using a request method not supported by that page."
+  },
+  "406": {
+    "code": 406,
+    "message": "Not Acceptable",
+    "description": "The server can only generate a response that is not accepted by the client."
+  },
+  "407": {
+    "code": 407,
+    "message": "Proxy Authentication Required",
+    "description": "The client must first authenticate itself with the proxy."
+  },
+  "408": {
+    "code": 408,
+    "message": "Request Timeout",
+    "description": "The server timed out waiting for the request."
+  },
+  "409": {
+    "code": 409,
+    "message": "Conflict",
+    "description": "The request could not be completed because of a conflict in the request."
+  },
+  "410": {
+    "code": 410,
+    "message": "Gone",
+    "description": "The requested page is no longer available."
+  },
+  "411": {
+    "code": 411,
+    "message": "Length Required",
+    "description": "The \"Content-Length\" is not defined. The server will not accept the request without it."
+  },
+  "412": {
+    "code": 412,
+    "message": "Precondition Failed",
+    "description": "The precondition given in the request evaluated to false by the server."
+  },
+  "413": {
+    "code": 413,
+    "message": "Request Entity Too Large",
+    "description": "The server will not accept the request, because the request entity is too large."
+  },
+  "414": {
+    "code": 414,
+    "message": "Request-URI Too Long",
+    "description": "The server will not accept the request, because the URL is too long. Occurs when you convert a POST request to a GET request with a long query information."
+  },
+  "415": {
+    "code": 415,
+    "message": "Unsupported Media Type",
+    "description": "The server will not accept the request, because the media type is not supported."
+  },
+  "416": {
+    "code": 416,
+    "message": "Requested Range Not Satisfiable",
+    "description": "The client has asked for a portion of the file, but the server cannot supply that portion."
+  },
+  "417": {
+    "code": 417,
+    "message": "Expectation Failed",
+    "description": "The server cannot meet the requirements of the Expect request-header field."
+  },
+  "418": {
+    "code": 418,
+    "message": "I'm a teapot",
+    "description": "Any attempt to brew coffee with a teapot should result in the error code \"418 I'm a teapot\". The resulting entity body MAY be short and stout."
+  },
+  "419": {
+    "code": 419,
+    "message": "Page Expired (Laravel Framework)",
+    "description": "Used by the Laravel Framework when a CSRF Token is missing or expired."
+  },
+  "420": {
+    "code": 420,
+    "message": "Method Failure (Spring Framework)",
+    "description": "A deprecated response used by the Spring Framework when a method has failed."
+  },
+  "421": {
+    "code": 421,
+    "message": "Misdirected Request",
+    "description": "The request was directed at a server that is not able to produce a response (for example because a connection reuse)."
+  },
+  "422": {
+    "code": 422,
+    "message": "Unprocessable Entity",
+    "description": "The request was well-formed but was unable to be followed due to semantic errors."
+  },
+  "423": {
+    "code": 423,
+    "message": "Locked",
+    "description": "The resource that is being accessed is locked."
+  },
+  "424": {
+    "code": 424,
+    "message": "Failed Dependency",
+    "description": "The request failed due to failure of a previous request (e.g., a PROPPATCH)."
+  },
+  "426": {
+    "code": 426,
+    "message": "Upgrade Required",
+    "description": "The client should switch to a different protocol such as TLS\/1.0, given in the Upgrade header field."
+  },
+  "428": {
+    "code": 428,
+    "message": "Precondition Required",
+    "description": "The origin server requires the request to be conditional."
+  },
+  "429": {
+    "code": 429,
+    "message": "Too Many Requests",
+    "description": "The user has sent too many requests in a given amount of time. Intended for use with rate limiting schemes."
+  },
+  "431": {
+    "code": 431,
+    "message": "Request Header Fields Too Large",
+    "description": "The server is unwilling to process the request because either an individual header field, or all the header fields collectively, are too large."
+  },
+  "440": {
+    "code": 440,
+    "message": "Login Time-out",
+    "description": "The client's session has expired and must log in again. (IIS)"
+  },
+  "444": {
+    "code": 444,
+    "message": "Connection Closed Without Response",
+    "description": "A non-standard status code used to instruct nginx to close the connection without sending a response to the client, most commonly used to deny malicious or malformed requests."
+  },
+  "449": {
+    "code": 449,
+    "message": "Retry With",
+    "description": "The server cannot honour the request because the user has not provided the required information. (IIS)"
+  },
+  "450": {
+    "code": 450,
+    "message": "Blocked by Windows Parental Controls",
+    "description": "The Microsoft extension code indicated when Windows Parental Controls are turned on and are blocking access to the requested webpage."
+  },
+  "451": {
+    "code": 451,
+    "message": "Unavailable For Legal Reasons",
+    "description": "A server operator has received a legal demand to deny access to a resource or to a set of resources that includes the requested resource."
+  },
+  "494": {
+    "code": 494,
+    "message": "Request Header Too Large",
+    "description": "Used by nginx to indicate the client sent too large of a request or header line that is too long."
+  },
+  "495": {
+    "code": 495,
+    "message": "SSL Certificate Error",
+    "description": "An expansion of the 400 Bad Request response code, used when the client has provided an invalid client certificate."
+  },
+  "496": {
+    "code": 496,
+    "message": "SSL Certificate Required",
+    "description": "An expansion of the 400 Bad Request response code, used when a client certificate is required but not provided."
+  },
+  "497": {
+    "code": 497,
+    "message": "HTTP Request Sent to HTTPS Port",
+    "description": "An expansion of the 400 Bad Request response code, used when the client has made a HTTP request to a port listening for HTTPS requests."
+  },
+  "498": {
+    "code": 498,
+    "message": "Invalid Token (Esri)",
+    "description": "Returned by ArcGIS for Server. Code 498 indicates an expired or otherwise invalid token."
+  },
+  "499": {
+    "code": 499,
+    "message": "Client Closed Request",
+    "description": "A non-standard status code introduced by nginx for the case when a client closes the connection while nginx is processing the request."
+  },
+  "5xx": {
+    "code": "5xx",
+    "message": "Server Error",
+    "description": "5xx error codes indicate that an error or unresolvable request occurred on the server side, whether that is a proxy or the origin host."
+  },
+  "500": {
+    "code": 500,
+    "message": "Internal Server Error",
+    "description": "An error has occurred in a server side script, a no more specific message is suitable."
+  },
+  "501": {
+    "code": 501,
+    "message": "Not Implemented",
+    "description": "The server either does not recognize the request method, or it lacks the ability to fulfill the request."
+  },
+  "502": {
+    "code": 502,
+    "message": "Bad Gateway",
+    "description": "The server was acting as a gateway or proxy and received an invalid response from the upstream server."
+  },
+  "503": {
+    "code": 503,
+    "message": "Service Unavailable",
+    "description": "The server is currently unavailable (overloaded or down)."
+  },
+  "504": {
+    "code": 504,
+    "message": "Gateway Timeout",
+    "description": "The server was acting as a gateway or proxy and did not receive a timely response from the upstream server."
+  },
+  "505": {
+    "code": 505,
+    "message": "HTTP Version Not Supported",
+    "description": "The server does not support the HTTP protocol version used in the request."
+  },
+  "506": {
+    "code": 506,
+    "message": "Variant Also Negotiates",
+    "description": "Transparent content negotiation for the request results in a circular reference."
+  },
+  "507": {
+    "code": 507,
+    "message": "Insufficient Storage",
+    "description": "The server is unable to store the representation needed to complete the request."
+  },
+  "508": {
+    "code": 508,
+    "message": "Loop Detected",
+    "description": "The server detected an infinite loop while processing the request (sent instead of 208 Already Reported)."
+  },
+  "509": {
+    "code": 509,
+    "message": "Bandwidth Limit Exceeded",
+    "description": "The server has exceeded the bandwidth specified by the server administrator; this is often used by shared hosting providers to limit the bandwidth of customers."
+  },
+  "510": {
+    "code": 510,
+    "message": "Not Extended",
+    "description": "Further extensions to the request are required for the server to fulfil it."
+  },
+  "511": {
+    "code": 511,
+    "message": "Network Authentication Required",
+    "description": "The client needs to authenticate to gain network access."
+  },
+  "520": {
+    "code": 520,
+    "message": "Unknown Error",
+    "description": "The 520 error is used as a \"catch-all response for when the origin server returns something unexpected\", listing connection resets, large headers, and empty or invalid responses as common triggers."
+  },
+  "521": {
+    "code": 521,
+    "message": "Web Server Is Down",
+    "description": "The origin server has refused the connection from Cloudflare."
+  },
+  "522": {
+    "code": 522,
+    "message": "Connection Timed Out",
+    "description": "Cloudflare could not negotiate a TCP handshake with the origin server."
+  },
+  "523": {
+    "code": 523,
+    "message": "Origin Is Unreachable",
+    "description": "Cloudflare could not reach the origin server; for example, if the DNS records for the origin server are incorrect."
+  },
+  "524": {
+    "code": 524,
+    "message": "A Timeout Occurred",
+    "description": "Cloudflare was able to complete a TCP connection to the origin server, but did not receive a timely HTTP response."
+  },
+  "525": {
+    "code": 525,
+    "message": "SSL Handshake Failed",
+    "description": "Cloudflare could not negotiate a SSL/TLS handshake with the origin server."
+  },
+  "526": {
+    "code": 526,
+    "message": "Invalid SSL Certificate",
+    "description": "Used by Cloudflare and Cloud Foundry's gorouter to indicate failure to validate the SSL/TLS certificate that the origin server presented."
+  },
+  "527": {
+    "code": 527,
+    "message": "Railgun Listener to Origin Error",
+    "description": "Error 527 indicates that the request timed out or failed after the WAN connection had been established."
+  },
+  "530": {
+    "code": 530,
+    "message": "Origin DNS Error",
+    "description": "Error 530 indicates that the requested host name could not be resolved on the Cloudflare network to an origin server."
+  },
+  "598": {
+    "code": 598,
+    "message": "Network Read Timeout Error",
+    "description": "Used by some HTTP proxies to signal a network read timeout behind the proxy to a client in front of the proxy."
+  }
+}


### PR DESCRIPTION
- Added support for HTTP client requests.
- New tab showing table with all collected requests with ability to show detailed information about the request and response.
- Collected HTTP requests are also shown on the timeline.
- Clockwork library [PR](https://github.com/itsgoingd/clockwork/pull/693).

Collected HTTP requests on the timeline.
<img width="1608" alt="Screenshot 2024-03-09 at 22 08 42" src="https://github.com/itsgoingd/clockwork/assets/821582/68159aeb-2ffb-461d-b363-b96681851a28">

The new HTTP requests tab.
<img width="1608" alt="Screenshot 2024-03-09 at 22 08 51" src="https://github.com/itsgoingd/clockwork/assets/821582/5efc1dae-5a18-4760-bc06-1020aff06eca">

Request details.
<img width="1496" alt="Screenshot 2024-03-09 at 22 10 16" src="https://github.com/itsgoingd/clockwork/assets/821582/54fc20e2-09cc-4906-a11e-42c22d5d809b">

Response details.
<img width="1496" alt="Screenshot 2024-03-09 at 22 09 52" src="https://github.com/itsgoingd/clockwork/assets/821582/5816c0aa-45b0-4ae8-9484-64b08e5a4d6d">
