### PR TITLE
Fix XDEBUG_PROFILE cookie always being set

### DIFF
--- a/src/platform/extension.js
+++ b/src/platform/extension.js
@@ -77,7 +77,7 @@ export default class Extension
 		return this.resolveTabUrl().then(url => {
 			return new Promise((accept, reject) => {
 				this.api.runtime.sendMessage(
-					{ action: 'setCookie', url, name }, message => accept(message)
+					{ action: 'getCookie', url, name }, message => accept(message)
 				)
 			})
 		})


### PR DESCRIPTION
The `platform.getCookie` method was sending a `setCookie` message, resulting in the XDEBUG_PROFILE cookie always being set.